### PR TITLE
S3(Fake): preserve encoding in bucketGetKey

### DIFF
--- a/amazon/s3/fake/src/main/kotlin/org/http4k/connect/amazon/s3/endpoints/getKey.kt
+++ b/amazon/s3/fake/src/main/kotlin/org/http4k/connect/amazon/s3/endpoints/getKey.kt
@@ -32,9 +32,11 @@ fun bucketGetKey(
     ?.let {
         bucketContent["${bucket}-${req.path("bucketKey")!!}"]
             ?.let {
-                Response(OK)
-                    .headers(getHeadersWithoutXHttp4kPrefix(it))
-                    .body(String(Base64.getDecoder().decode(it.content)))
+                Base64.getDecoder().decode(it.content).let { bytes ->
+                    Response(OK)
+                        .headers(getHeadersWithoutXHttp4kPrefix(it))
+                        .body(bytes.inputStream(), bytes.size.toLong())
+                }
             } ?: Response(NOT_FOUND).with(lens of S3Error("NoSuchKey"))
     }
     ?: invalidBucketNameResponse())

--- a/amazon/s3/fake/src/test/kotlin/org/http4k/connect/amazon/s3/fakeS3Tests.kt
+++ b/amazon/s3/fake/src/test/kotlin/org/http4k/connect/amazon/s3/fakeS3Tests.kt
@@ -43,6 +43,24 @@ class FakeS3BucketTest : S3BucketContract(FakeS3()) {
         }
     }
 
+    @Test
+    fun `preserve encoding`() {
+        try {
+
+            assertThat(
+                s3Bucket.putObject(
+                    key, "génial".byteInputStream(Charsets.ISO_8859_1), listOf()
+                ).successValue(), equalTo(Unit)
+            )
+
+            assertThat(
+                s3Bucket[key].successValue()!!.reader(Charsets.ISO_8859_1).readText(), equalTo("génial")
+            )
+        } finally {
+            s3Bucket.deleteObject(key)
+            s3Bucket.deleteBucket()
+        }
+    }
 }
 
 class FakeS3BucketPathStyleTest : S3BucketContract(FakeS3()) {


### PR DESCRIPTION
Hi!

A problem occurred on encoding when I upgraded http4k-connect from `3.0.2.0` to `3.4.1.0` and I found out it is the `bucketGetKey` method causing this.

To reproduce, you can run the new test `preserve encoding` with the current code. My guess is that when you do the following
```kotlin
String(Base64.getDecoder().decode(it.content))
```
The encoding is lost, because `String` basically works with UTF-8. The solution is to use the `inputStream` instead.