### PR TITLE
Fix FakeS3 to support copying of objects with prefixes

### DIFF
--- a/amazon/s3/fake/src/main/kotlin/org/http4k/connect/amazon/s3/endpoints/copyKey.kt
+++ b/amazon/s3/fake/src/main/kotlin/org/http4k/connect/amazon/s3/endpoints/copyKey.kt
@@ -29,7 +29,7 @@ private fun copyKey(
     req: Request,
     buckets: Storage<Unit>,
     clock: Clock
-) = bucketContent[req.header("x-amz-copy-source")!!.split("/")
+) = bucketContent[req.header("x-amz-copy-source")!!.split("/", limit = 2)
     .let { (sourceBucket, sourceKey) -> "$sourceBucket-$sourceKey" }]
     ?.let {
         putKey(


### PR DESCRIPTION
Previously the implementation consistently returned 404's because the source key could not be found in the bucketContent