### PR TITLE
Implement dynamodb fake scan

### DIFF
--- a/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/scan.kt
+++ b/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/scan.kt
@@ -6,7 +6,22 @@ import org.http4k.connect.amazon.dynamodb.action.Scan
 import org.http4k.connect.amazon.dynamodb.action.ScanResponse
 import org.http4k.connect.storage.Storage
 
-fun AmazonJsonFake.scan(tables: Storage<DynamoTable>) = route<Scan> {
-    // todo
-    ScanResponse()
+fun AmazonJsonFake.scan(tables: Storage<DynamoTable>) = route<Scan> { scan ->
+    val table = tables[scan.TableName.value] ?: return@route null
+
+    val items = table.items
+        .asSequence()
+        .mapNotNull {it.condition(
+            expression = scan.FilterExpression,
+            expressionAttributeNames = scan.ExpressionAttributeNames,
+            expressionAttributeValues = scan.ExpressionAttributeValues
+        ) }
+        .map { it.asItemResult() }
+        .take(scan.Limit ?: Int.MAX_VALUE)
+        .toList()
+
+    ScanResponse(
+        Count = items.size,
+        Items = items
+    )
 }

--- a/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/DynamoDbSource.kt
+++ b/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/DynamoDbSource.kt
@@ -1,0 +1,46 @@
+package org.http4k.connect.amazon.dynamodb
+
+import org.http4k.client.JavaHttpClient
+import org.http4k.connect.amazon.fakeAwsEnvironment
+import org.http4k.connect.assumeDockerDaemonRunning
+import org.http4k.core.Uri
+import org.http4k.core.then
+import org.http4k.filter.ClientFilters
+import org.http4k.filter.debug
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+
+interface DynamoDbSource {
+    val dynamo: DynamoDb
+}
+
+class FakeDynamoDbSource: DynamoDbSource {
+    override val dynamo = DynamoDb.Http(
+        fakeAwsEnvironment.region,
+        { fakeAwsEnvironment.credentials },
+        FakeDynamoDb().debug()
+    )
+}
+
+class LocalDynamoDbSource: DynamoDbSource {
+    init {
+        assumeDockerDaemonRunning()
+    }
+
+    private val http by lazy {
+        ClientFilters.SetBaseUriFrom(Uri.of("http://localhost:${container.getMappedPort(8000)}"))
+            .then(JavaHttpClient())
+    }
+
+    private val container: GenericContainer<*> = GenericContainer(DockerImageName.parse("amazon/dynamodb-local:1.15.0"))
+        .withExposedPorts(8000)
+        .also { it.start() }
+
+    override val dynamo = DynamoDb.Http(
+        fakeAwsEnvironment.region,
+        { fakeAwsEnvironment.credentials },
+        http.debug()
+    )
+}

--- a/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/DynamoDbScanContract.kt
+++ b/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/DynamoDbScanContract.kt
@@ -1,0 +1,84 @@
+package org.http4k.connect.amazon.dynamodb.endpoints
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.hasElement
+import com.natpryce.hamkrest.hasSize
+import org.http4k.connect.amazon.dynamodb.DynamoDbSource
+import org.http4k.connect.amazon.dynamodb.FakeDynamoDbSource
+import org.http4k.connect.amazon.dynamodb.LocalDynamoDbSource
+import org.http4k.connect.amazon.dynamodb.attrN
+import org.http4k.connect.amazon.dynamodb.attrS
+import org.http4k.connect.amazon.dynamodb.createItem
+import org.http4k.connect.amazon.dynamodb.createTable
+import org.http4k.connect.amazon.dynamodb.model.BillingMode
+import org.http4k.connect.amazon.dynamodb.model.KeySchema
+import org.http4k.connect.amazon.dynamodb.model.TableName
+import org.http4k.connect.amazon.dynamodb.model.asAttributeDefinition
+import org.http4k.connect.amazon.dynamodb.model.compound
+import org.http4k.connect.amazon.dynamodb.putItem
+import org.http4k.connect.amazon.dynamodb.sample
+import org.http4k.connect.amazon.dynamodb.scan
+import org.http4k.connect.successValue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+abstract class DynamoDbScanContract: DynamoDbSource {
+
+    private val table = TableName.sample()
+    private val item1 = createItem("hash1", 1)
+    private val item2 = createItem("hash2", 1)
+    private val item3 = createItem("hash3", 2)
+
+    @BeforeEach
+    fun createTable() {
+        dynamo.createTable(
+            table,
+            KeySchema = KeySchema.compound(attrS.name),
+            AttributeDefinitions = listOf(attrS.asAttributeDefinition()),
+            BillingMode = BillingMode.PAY_PER_REQUEST
+        ).successValue()
+
+        dynamo.waitForExist(table)
+
+        dynamo.putItem(table, item1).successValue()
+        dynamo.putItem(table, item2).successValue()
+        dynamo.putItem(table, item3).successValue()
+    }
+
+    @Test
+    fun `scan table`() {
+        val result = dynamo.scan(table).successValue()
+
+        assertThat(result.Count, equalTo(3))
+        assertThat(result.items, hasSize(equalTo(3)))
+        assertThat(result.items, hasElement(item1))
+        assertThat(result.items, hasElement(item2))
+        assertThat(result.items, hasElement(item3))
+    }
+
+    @Test
+    fun `scan with filter`() {
+        val result = dynamo.scan(
+            TableName = table,
+            FilterExpression = "$attrN = :val1",
+            ExpressionAttributeValues = mapOf(":val1" to attrN.asValue(1))
+        ).successValue()
+
+        assertThat(result.Count, equalTo(2))
+        assertThat(result.items, hasSize(equalTo(2)))
+        assertThat(result.items, hasElement(item1))
+        assertThat(result.items, hasElement(item2))
+    }
+
+    @Test
+    fun `scan with limit`() {
+        val result = dynamo.scan(TableName = table, Limit = 2).successValue()
+
+        assertThat(result.Count, equalTo(2))
+        assertThat(result.items, hasSize(equalTo(2)))
+    }
+}
+
+class LocalDynamoDbScanTest: DynamoDbScanContract(), DynamoDbSource by LocalDynamoDbSource()
+class FakeDynamoDbScanTest: DynamoDbScanContract(), DynamoDbSource by FakeDynamoDbSource()

--- a/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/DynamoDbUpdateItemContract.kt
+++ b/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/DynamoDbUpdateItemContract.kt
@@ -1,0 +1,153 @@
+package org.http4k.connect.amazon.dynamodb.endpoints
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.connect.amazon.dynamodb.DynamoDb
+import org.http4k.connect.amazon.dynamodb.DynamoDbSource
+import org.http4k.connect.amazon.dynamodb.FakeDynamoDbSource
+import org.http4k.connect.amazon.dynamodb.LocalDynamoDbSource
+import org.http4k.connect.amazon.dynamodb.attrN
+import org.http4k.connect.amazon.dynamodb.attrS
+import org.http4k.connect.amazon.dynamodb.attrSS
+import org.http4k.connect.amazon.dynamodb.createItem
+import org.http4k.connect.amazon.dynamodb.createTable
+import org.http4k.connect.amazon.dynamodb.getItem
+import org.http4k.connect.amazon.dynamodb.model.BillingMode
+import org.http4k.connect.amazon.dynamodb.model.Item
+import org.http4k.connect.amazon.dynamodb.model.KeySchema
+import org.http4k.connect.amazon.dynamodb.model.TableName
+import org.http4k.connect.amazon.dynamodb.model.asAttributeDefinition
+import org.http4k.connect.amazon.dynamodb.model.compound
+import org.http4k.connect.amazon.dynamodb.model.with
+import org.http4k.connect.amazon.dynamodb.putItem
+import org.http4k.connect.amazon.dynamodb.sample
+import org.http4k.connect.amazon.dynamodb.updateItem
+import org.http4k.connect.successValue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+abstract class DynamoDbUpdateItemContract {
+
+    abstract val dynamo: DynamoDb
+
+    companion object {
+        private val table = TableName.sample()
+
+        private val item = createItem("hash1", 1)
+        private val key = Item(attrS of "hash1")
+    }
+
+    @BeforeEach
+    fun createTable() {
+        dynamo.createTable(
+            table,
+            KeySchema = KeySchema.compound(attrS.name),
+            AttributeDefinitions = listOf(attrS.asAttributeDefinition()),
+            BillingMode = BillingMode.PAY_PER_REQUEST
+        ).successValue()
+
+        dynamo.waitForExist(table)
+    }
+
+    @Test
+    fun `set value on existing item`() {
+        dynamo.putItem(TableName = table, Item = item).successValue()
+
+        dynamo.updateItem(
+            TableName = table,
+            Key = key,
+            UpdateExpression = "SET $attrN = :val1",
+            ExpressionAttributeValues = mapOf(":val1" to attrN.asValue(999))
+        ).successValue()
+
+        assertThat(getItem(), equalTo(item.with(attrN of 999)))
+    }
+
+    @Test
+    fun `set value on missing item`() {
+        dynamo.updateItem(
+            TableName = table,
+            Key = key,
+            UpdateExpression = "SET $attrN = :val1",
+            ExpressionAttributeValues = mapOf(":val1" to attrN.asValue(999))
+        ).successValue()
+
+        assertThat(getItem(), equalTo(Item(attrS of "hash1", attrN of 999)))
+    }
+
+    @Test
+    fun `increment value on existing item`() {
+        dynamo.putItem(TableName = table, Item = item).successValue()
+
+        dynamo.updateItem(
+            TableName = table,
+            Key = key,
+            UpdateExpression = "SET $attrN = $attrN + :val1",
+            ExpressionAttributeValues = mapOf(":val1" to attrN.asValue(2))
+        ).successValue()
+
+        assertThat(getItem(), equalTo(item.with(attrN of 3)))
+    }
+
+    @Test
+    fun `remove attribute from existing item`() {
+        dynamo.putItem(TableName = table, Item = item).successValue()
+
+        dynamo.updateItem(
+            TableName = table,
+            Key = key,
+            UpdateExpression = "REMOVE $attrN",
+        ).successValue()
+
+        assertThat(getItem(), equalTo(item - attrN.name))
+    }
+
+    @Test
+    fun `remove attribute from missing item`() {
+        dynamo.updateItem(
+            TableName = table,
+            Key = key,
+            UpdateExpression = "REMOVE $attrN",
+        ).successValue()
+
+        assertThat(getItem(), equalTo(key))
+    }
+
+    @Test
+    fun `add element to set`() {
+        dynamo.putItem(TableName = table, Item = item).successValue()
+
+        dynamo.updateItem(
+            TableName = table,
+            Key = key,
+            UpdateExpression = "ADD $attrSS :val1",
+            ExpressionAttributeValues = mapOf(":val1" to attrSS.asValue(setOf("foo")))
+        ).successValue()
+
+        assertThat(getItem(), equalTo(item.with(attrSS of setOf("345", "567", "foo"))))
+    }
+
+    @Test
+    fun `delete element from set`() {
+        dynamo.putItem(TableName = table, Item = item).successValue()
+
+        dynamo.updateItem(
+            TableName = table,
+            Key = key,
+            UpdateExpression = "DELETE $attrSS :val1",
+            ExpressionAttributeValues = mapOf(":val1" to attrSS.asValue(setOf("345")))
+        ).successValue()
+
+        assertThat(getItem(), equalTo(item.with(attrSS of setOf("567"))))
+    }
+
+    private fun getItem(): Item? = dynamo.getItem(
+        TableName = table,
+        Key = Item(attrS of "hash1")
+    ).successValue().item
+}
+
+@Disabled
+class FakeDynamoDbUpdateItemTest: DynamoDbUpdateItemContract(), DynamoDbSource by FakeDynamoDbSource()
+class LocalDynamoDbUpdateItemTest: DynamoDbUpdateItemContract(), DynamoDbSource by LocalDynamoDbSource()

--- a/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/dynamoDbContractHelpers.kt
+++ b/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/dynamoDbContractHelpers.kt
@@ -1,0 +1,20 @@
+package org.http4k.connect.amazon.dynamodb.endpoints
+
+import dev.forkhandles.result4k.Success
+import org.http4k.connect.amazon.dynamodb.DynamoDb
+import org.http4k.connect.amazon.dynamodb.action.DescribedTable
+import org.http4k.connect.amazon.dynamodb.describeTable
+import org.http4k.connect.amazon.dynamodb.model.TableName
+import java.time.Duration
+import java.time.Instant
+
+fun DynamoDb.waitForExist(name: TableName, timeout: Duration = Duration.ofSeconds(10)) {
+    val waitStart = Instant.now()
+    while (Duration.between(waitStart, Instant.now()) < timeout) {
+        if (describeTable(name) is Success<DescribedTable>) {
+            return
+        }
+        Thread.sleep(1000)
+    }
+    throw IllegalStateException("Table $name was not created after $timeout")
+}


### PR DESCRIPTION
- Implemented dynamodb `scan` operation, with tests for the fake and local variants
- added local test variant for the `query` operation, as a sanity check against the fake variant
- added local test variant for the `updateItem` operation; fake variant is not yet implemented