### PR TITLE
Fake DynamoDb PutItem bugfix

### DIFF
--- a/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/DynamoTable.kt
+++ b/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/DynamoTable.kt
@@ -1,5 +1,6 @@
 package org.http4k.connect.amazon.dynamodb
 
+import org.http4k.connect.amazon.dynamodb.endpoints.keySchema
 import org.http4k.connect.amazon.dynamodb.model.Item
 import org.http4k.connect.amazon.dynamodb.model.Key
 import org.http4k.connect.amazon.dynamodb.model.TableDescription
@@ -7,8 +8,19 @@ import org.http4k.connect.amazon.dynamodb.model.TableDescription
 data class DynamoTable(val table: TableDescription, val items: List<Item> = emptyList()) {
     fun retrieve(key: Key) = items.firstOrNull { it.matches(key) }
 
-    fun withItem(item: Item) = copy(items = items + item)
+    fun withItem(item: Item) = retrieve(item.key())
+        .let { existing -> if (existing != null) withoutItem(existing) else this }
+        .let { it.copy(items = it.items + item) }
+
     fun withoutItem(key: Key) = copy(items = items.filterNot { it.matches(key) })
 
     private fun Item.matches(key: Key) = toList().containsAll(key.toList())
+    private fun Item.key(): Key {
+        val schema = keySchema() ?: return Key()
+
+        return schema.mapNotNull { key ->
+            val value = this[key.AttributeName]
+            if (value == null) null else key.AttributeName to value
+        }.toMap()
+    }
 }

--- a/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/DynamoDbPutItemContract.kt
+++ b/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/DynamoDbPutItemContract.kt
@@ -1,0 +1,69 @@
+package org.http4k.connect.amazon.dynamodb.endpoints
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.connect.amazon.dynamodb.DynamoDbSource
+import org.http4k.connect.amazon.dynamodb.FakeDynamoDbSource
+import org.http4k.connect.amazon.dynamodb.LocalDynamoDbSource
+import org.http4k.connect.amazon.dynamodb.attrN
+import org.http4k.connect.amazon.dynamodb.attrS
+import org.http4k.connect.amazon.dynamodb.createTable
+import org.http4k.connect.amazon.dynamodb.getItem
+import org.http4k.connect.amazon.dynamodb.model.BillingMode
+import org.http4k.connect.amazon.dynamodb.model.Item
+import org.http4k.connect.amazon.dynamodb.model.Key
+import org.http4k.connect.amazon.dynamodb.model.KeySchema
+import org.http4k.connect.amazon.dynamodb.model.TableName
+import org.http4k.connect.amazon.dynamodb.model.asAttributeDefinition
+import org.http4k.connect.amazon.dynamodb.model.compound
+import org.http4k.connect.amazon.dynamodb.putItem
+import org.http4k.connect.amazon.dynamodb.sample
+import org.http4k.connect.successValue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+abstract class DynamoDbPutItemContract: DynamoDbSource {
+
+    private val table = TableName.sample()
+
+    @BeforeEach
+    fun createTable() {
+        dynamo.createTable(
+            table,
+            KeySchema = KeySchema.compound(attrS.name),
+            AttributeDefinitions = listOf(attrS.asAttributeDefinition()),
+            BillingMode = BillingMode.PAY_PER_REQUEST
+        ).successValue()
+
+        dynamo.waitForExist(table)
+    }
+
+    @Test
+    fun `put item`() {
+        val item = Item(attrS of "hash1", attrN of 1)
+
+        dynamo.putItem(table, item)
+
+        assertThat(
+            dynamo.getItem(table, Key(attrS of "hash1")).successValue().item,
+            equalTo(item)
+        )
+    }
+
+    @Test
+    fun `replace item`() {
+        val original = Item(attrS of "hash1", attrN of 1)
+        val updated = Item(attrS of "hash1", attrN of 2)
+
+        dynamo.putItem(table, original)
+        dynamo.putItem(table, updated)
+
+        assertThat(
+            dynamo.getItem(table, Key(attrS of "hash1")).successValue().item,
+            equalTo(updated)
+        )
+    }
+}
+
+class FakeDynamoDbPutItemContract: DynamoDbPutItemContract(), DynamoDbSource by FakeDynamoDbSource()
+class LocalDynamoDbPutItemContract: DynamoDbPutItemContract(), DynamoDbSource by LocalDynamoDbSource()

--- a/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/DynamoDbUpdateItemContract.kt
+++ b/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/DynamoDbUpdateItemContract.kt
@@ -2,7 +2,6 @@ package org.http4k.connect.amazon.dynamodb.endpoints
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
-import org.http4k.connect.amazon.dynamodb.DynamoDb
 import org.http4k.connect.amazon.dynamodb.DynamoDbSource
 import org.http4k.connect.amazon.dynamodb.FakeDynamoDbSource
 import org.http4k.connect.amazon.dynamodb.LocalDynamoDbSource
@@ -26,9 +25,7 @@ import org.http4k.connect.successValue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-abstract class DynamoDbUpdateItemContract {
-
-    abstract val dynamo: DynamoDb
+abstract class DynamoDbUpdateItemContract: DynamoDbSource {
 
     companion object {
         private val table = TableName.sample()


### PR DESCRIPTION
The fake dynamodb putItem operation will now properly replace an existing item with the same primary key