### PR TITLE
Fix request/response for fake dynamodb batch operations

### DIFF
--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/model/TableName.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/model/TableName.kt
@@ -1,10 +1,10 @@
 package org.http4k.connect.amazon.dynamodb.model
 
-import dev.forkhandles.values.StringValue
+import dev.forkhandles.values.AbstractComparableValue
 import dev.forkhandles.values.StringValueFactory
 import dev.forkhandles.values.regex
 
 
-class TableName private constructor(value: String) : StringValue(value) {
+class TableName private constructor(value: String) : AbstractComparableValue<TableName, String>(value) {
     companion object : StringValueFactory<TableName>(::TableName, "[a-zA-Z0-9_.-]+".regex)
 }

--- a/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/batchGetItem.kt
+++ b/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/batchGetItem.kt
@@ -6,8 +6,8 @@ import org.http4k.connect.amazon.dynamodb.action.BatchGetItem
 import org.http4k.connect.amazon.dynamodb.action.BatchGetItems
 import org.http4k.connect.storage.Storage
 
-fun AmazonJsonFake.batchGetItem(tables: Storage<DynamoTable>) = route<BatchGetItem> {
-    BatchGetItems(it.RequestItems.flatMap { (tableName, get) ->
+fun AmazonJsonFake.batchGetItem(tables: Storage<DynamoTable>) = route<BatchGetItem> { batchGetItem ->
+    val items = batchGetItem.RequestItems.flatMap { (tableName, get) ->
         get.Keys.mapNotNull { key ->
             tables[tableName.value]
                 ?.let { table ->
@@ -17,6 +17,12 @@ fun AmazonJsonFake.batchGetItem(tables: Storage<DynamoTable>) = route<BatchGetIt
                 ?.let { tableName.value to it }
         }
     }
-        .groupBy { it.first }
-        .mapValues { it.value.map { it.second } })
+
+
+    BatchGetItems(
+        Responses = items
+            .groupBy { it.first }
+            .mapValues { it.value.map { it.second } },
+        UnprocessedKeys = emptyMap()
+    )
 }

--- a/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/batchWriteItem.kt
+++ b/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/batchWriteItem.kt
@@ -21,5 +21,5 @@ fun AmazonJsonFake.batchWriteItem(tables: Storage<DynamoTable>) = route<BatchWri
                         }
                 }
         }
-    BatchWriteItems()
+    BatchWriteItems(UnprocessedItems = emptyMap())
 }

--- a/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/FakeDynamoDbTest.kt
+++ b/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/FakeDynamoDbTest.kt
@@ -15,11 +15,6 @@ class FakeDynamoDbTest : DynamoDbContract(ZERO) {
     }
 
     @Disabled
-    override fun `batch operations`() {
-        TODO("support")
-    }
-
-    @Disabled
     override fun `partiSQL operations`() {
         TODO("support")
     }


### PR DESCRIPTION
- TableName failed to deserialize because it wasn't `Comparable`
- `BatchGetItems` and `BatchWriteItems` responses failed to satisfy the contract because a property was `null` instead of `emptyMap`