### PR TITLE
Fix equality and comparison for numeric attribute values

### DIFF
--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/model/AttributeValue.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/model/AttributeValue.kt
@@ -41,9 +41,46 @@ data class AttributeValue internal constructor(
             ")"
     }
 
+    override fun hashCode() = when {
+        B != null -> B.hashCode()
+        BOOL != null -> "bool$BOOL".hashCode()
+        BS != null -> BS.hashCode()
+        L != null -> L.hashCode()
+        M != null -> M.hashCode()
+        N != null -> N.hashCode()
+        NS != null -> NS.hashCode()
+        NULL != null -> "null$NULL".hashCode()
+        S != null -> S.hashCode()
+        SS != null -> SS.hashCode()
+        else -> 0
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return when {
+            other !is AttributeValue -> false
+            B != null && other.B != null -> B == other.B
+            BOOL != null-> BOOL == other.BOOL
+            BS != null -> BS == other.BS
+            L != null -> L == other.L
+            M != null -> M == other.M
+            // N must be equated by comparing as BigDecimal; otherwise 123 != 123.0
+            N != null && other.N != null -> N.toBigDecimal().compareTo(other.N.toBigDecimal()) == 0
+            NS != null && other.NS != null -> {
+                if (NS.size != other.NS.size) return false
+                val thisNumbers = NS.map { it.toBigDecimal() }.sorted()
+                val otherNumbers = other.NS.map { it.toBigDecimal() }.sorted()
+                thisNumbers.zip(otherNumbers).all { it.first.compareTo(it.second) == 0 }
+            }
+            NULL != null -> NULL == other.NULL
+            S != null -> S == other.S
+            SS != null -> SS == other.SS
+            else -> false
+        }
+    }
+
     override fun compareTo(other: AttributeValue) =  when {
         S != null && other.S != null -> S.compareTo(other.S)
-        N != null && other.N != null -> N.compareTo(other.N)
+        N != null && other.N != null -> N.toBigDecimal().compareTo(other.N.toBigDecimal())
         B != null && other.B != null -> B.decoded().compareTo(other.B.decoded())
         else -> 0
     }

--- a/amazon/dynamodb/client/src/test/kotlin/org/http4k/connect/amazon/dynamodb/model/AttributeValueTest.kt
+++ b/amazon/dynamodb/client/src/test/kotlin/org/http4k/connect/amazon/dynamodb/model/AttributeValueTest.kt
@@ -1,0 +1,34 @@
+package org.http4k.connect.amazon.dynamodb.model
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.greaterThan
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class AttributeValueTest {
+
+    @Test
+    fun `int = decimal for N`() {
+        val int = AttributeValue.Num(123)
+        val decimal = AttributeValue.Num(BigDecimal("123.0"))
+
+        assertThat(int, equalTo(decimal))
+    }
+
+    @Test
+    fun `int = decimal in NS`() {
+        val intSet = AttributeValue.NumSet(setOf(123))
+        val decimalSet = AttributeValue.NumSet(setOf(BigDecimal("123.0")))
+
+        assertThat(intSet, equalTo(decimalSet))
+    }
+
+    @Test
+    fun `comparing numbers not done lexicographically`() {
+        val higher = AttributeValue.Num(123)
+        val lower = AttributeValue.Num(45)
+
+        assertThat(higher, greaterThan(lower))
+    }
+}


### PR DESCRIPTION
The existing `AttributeValue` equality and comparison operators don't work for numeric types, since they currently operate lexicographically.

For Example, these currently evaluate to false:
- `123` > `45` 
- `123` == `123.0`

The equality issue is of particular concern when `Item` is deserialized by moshi; it will always read numbers as double.  This behaviour is known in `AutoMarshalingExtensionsTest.can roundtrip a dynamo item with autoDynamoLens`.  Unfortunately, `BigDecimal.equals` still believes `123` != `123.0`, so we cannot even fix this by making the `N` property into a `BigDecimal`, so must use `BigDecimal.compareTo` to check for effective equality.
