### PR TITLE
Add ability to update the DynamoDbMoshi marshaller with new config

### DIFF
--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/DynamoDbMoshi.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/DynamoDbMoshi.kt
@@ -5,6 +5,7 @@ import com.squareup.moshi.Moshi
 import org.http4k.connect.amazon.dynamodb.model.AttributeName
 import org.http4k.connect.amazon.dynamodb.model.IndexName
 import org.http4k.connect.amazon.dynamodb.model.TableName
+import org.http4k.format.AutoMappingConfiguration
 import org.http4k.format.AwsCoreJsonAdapterFactory
 import org.http4k.format.ConfigurableMoshi
 import org.http4k.format.ListAdapter
@@ -15,20 +16,25 @@ import org.http4k.format.withAwsCoreMappings
 import org.http4k.format.withStandardMappings
 import se.ansman.kotshi.KotshiJsonAdapterFactory
 
+private fun standardConfig() = Moshi.Builder()
+    .add(KotshiDynamoDbJsonAdapterFactory)
+    .add(AwsCoreJsonAdapterFactory())
+    .add(MapAdapter)
+    .add(ListAdapter)
+    .asConfigurable()
+    .withStandardMappings()
+    .withAwsCoreMappings()
+    .value(AttributeName)
+    .value(IndexName)
+    .value(TableName)
+
 object DynamoDbMoshi : ConfigurableMoshi(
-    Moshi.Builder()
-        .add(KotshiDynamoDbJsonAdapterFactory)
-        .add(AwsCoreJsonAdapterFactory())
-        .add(MapAdapter)
-        .add(ListAdapter)
-        .asConfigurable()
-        .withStandardMappings()
-        .withAwsCoreMappings()
-        .value(AttributeName)
-        .value(IndexName)
-        .value(TableName)
-        .done()
-)
+    standardConfig().done()
+) {
+    fun update(
+        fn: AutoMappingConfiguration<Moshi.Builder>.() -> AutoMappingConfiguration<Moshi.Builder>
+    ) = ConfigurableMoshi(standardConfig().let(fn).done())
+}
 
 @KotshiJsonAdapterFactory
 interface DynamoDbJsonAdapterFactory : JsonAdapter.Factory

--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/DynamoDbMoshi.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/DynamoDbMoshi.kt
@@ -32,8 +32,8 @@ object DynamoDbMoshi : ConfigurableMoshi(
     standardConfig().done()
 ) {
     fun update(
-        fn: AutoMappingConfiguration<Moshi.Builder>.() -> AutoMappingConfiguration<Moshi.Builder>
-    ) = ConfigurableMoshi(standardConfig().let(fn).done())
+        configureFn: AutoMappingConfiguration<Moshi.Builder>.() -> AutoMappingConfiguration<Moshi.Builder>
+    ) = ConfigurableMoshi(standardConfig().let(configureFn).done())
 }
 
 @KotshiJsonAdapterFactory


### PR DESCRIPTION
The only way I can add custom mappers (i.e. for values4k classes) is by making a new `ConfigurableMoshi` with a reflective backend.  `kotlinx-metadata` works, but I would rather avoid adding reflection to my lambdas.  It's impossible for me to inject the existing Kotshi factory into a new `ConfigurableMoshi`, because the class is module internal.

This new `update` method will allow me to make a copy of an existing `DynamoDbMoshi`, while providing additional custom marshallers.  For example:

```kotlin
val lens = DynamoDbMoshi.update {
    value(CustomValue)
}.autoDynamoLens<MyDbObj>()
```

I see an `update` method like this being very powerful in the built-in `http4k-format` marshallers as well.