### PR TITLE
Add Amazon RegionProvider with environment, profile, and imds support

### DIFF
--- a/amazon/core/src/main/kotlin/org/http4k/connect/amazon/RegionProvider.kt
+++ b/amazon/core/src/main/kotlin/org/http4k/connect/amazon/RegionProvider.kt
@@ -1,0 +1,17 @@
+package org.http4k.connect.amazon
+
+import org.http4k.cloudnative.env.Environment
+import org.http4k.connect.amazon.core.model.Region
+
+fun interface RegionProvider: () -> Region? {
+
+    fun orElseThrow() = requireNotNull(invoke()) { "AWS Region not found in provider chain" }
+    infix fun orElse(other: RegionProvider) = RegionProvider { invoke() ?: other() }
+
+    companion object
+}
+
+fun RegionProvider.Companion.Environment(env: Environment) = RegionProvider { AWS_REGION_OPTIONAL(env) }
+
+fun RegionProvider.Companion.Environment(env: Map<String, String> = System.getenv()) =
+    Environment(Environment.from(env))

--- a/amazon/core/src/main/kotlin/org/http4k/connect/amazon/extensions.kt
+++ b/amazon/core/src/main/kotlin/org/http4k/connect/amazon/extensions.kt
@@ -17,6 +17,7 @@ import java.io.File
 import kotlin.io.path.Path
 
 val AWS_REGION = EnvironmentKey.value(Region).required("AWS_REGION")
+val AWS_REGION_OPTIONAL = EnvironmentKey.value(Region).optional("AWS_REGION")
 val AWS_ACCESS_KEY_ID = EnvironmentKey.value(AccessKeyId).required("AWS_ACCESS_KEY_ID")
 val AWS_SECRET_ACCESS_KEY = EnvironmentKey.value(SecretAccessKey).required("AWS_SECRET_ACCESS_KEY")
 val AWS_ACCESS_KEY_ID_OPTIONAL = EnvironmentKey.value(AccessKeyId).optional("AWS_ACCESS_KEY_ID")

--- a/amazon/core/src/main/kotlin/org/http4k/connect/amazon/profileRegionProvider.kt
+++ b/amazon/core/src/main/kotlin/org/http4k/connect/amazon/profileRegionProvider.kt
@@ -1,0 +1,12 @@
+package org.http4k.connect.amazon
+
+import org.http4k.cloudnative.env.Environment
+import org.http4k.connect.amazon.core.model.AwsProfile
+import org.http4k.connect.amazon.core.model.ProfileName
+import java.nio.file.Path
+
+fun RegionProvider.Companion.Profile(profileName: ProfileName, credentialsPath: Path) =
+    RegionProvider { AwsProfile.loadProfiles(credentialsPath)[profileName]?.region }
+
+fun RegionProvider.Companion.Profile(env: Environment) =
+    Profile(AWS_PROFILE(env), AWS_CREDENTIAL_PROFILES_FILE(env))

--- a/amazon/core/src/test/kotlin/org/http4k/connect/amazon/EnvironmentRegionProviderTest.kt
+++ b/amazon/core/src/test/kotlin/org/http4k/connect/amazon/EnvironmentRegionProviderTest.kt
@@ -1,0 +1,29 @@
+package org.http4k.connect.amazon
+
+import com.natpryce.hamkrest.absent
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.cloudnative.env.Environment
+import org.http4k.connect.amazon.core.model.Region
+import org.junit.jupiter.api.Test
+
+class EnvironmentRegionProviderTest {
+
+    @Test
+    fun `region not in environment`() = assertThat(
+        RegionProvider.Environment(Environment.ENV).invoke(),
+        absent()
+    )
+
+    @Test
+    fun `malformed region in environment`() = assertThat(
+        RegionProvider.Environment(mapOf("AWS_REGION" to "nowhere")).invoke(),
+        equalTo(Region.of("nowhere"))
+    )
+
+    @Test
+    fun `region in environment`() = assertThat(
+        RegionProvider.Environment(mapOf("AWS_REGION" to "ca-central-1")).invoke(),
+        equalTo(Region.CA_CENTRAL_1)
+    )
+}

--- a/amazon/core/src/test/kotlin/org/http4k/connect/amazon/ProfileRegionProviderTest.kt
+++ b/amazon/core/src/test/kotlin/org/http4k/connect/amazon/ProfileRegionProviderTest.kt
@@ -1,0 +1,72 @@
+package org.http4k.connect.amazon
+
+import com.natpryce.hamkrest.absent
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.aws.AwsCredentials
+import org.http4k.cloudnative.env.Environment
+import org.http4k.connect.amazon.core.model.ProfileName
+import org.http4k.connect.amazon.core.model.Region
+import org.http4k.core.with
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import kotlin.io.path.Path
+
+class ProfileRegionProviderTest {
+
+    private val profileFile = Files.createTempFile("credentials", "ini").also {
+        it.toFile().writeText("""
+            [default]
+            aws_access_key_id = key123
+            aws_secret_access_key = secret123
+            region = ca-central-1
+            
+            [dev]
+            aws_access_key_id = key456
+            aws_secret_access_key = secret456
+            region = us-east-1
+            
+            [prod]
+            aws_access_key_id = key789
+            aws_secret_access_key = secret789
+        """)
+    }
+
+    @AfterEach
+    fun cleanup() {
+        profileFile.toFile().delete()
+    }
+
+    private fun getRegion(name: ProfileName) = RegionProvider.Profile(name, profileFile).invoke()
+
+    @Test
+    fun `default profile in custom file`() = assertThat(
+        getRegion(ProfileName.of("default")),
+        equalTo(Region.CA_CENTRAL_1)
+    )
+
+    @Test
+    fun `custom profile in custom file`() = assertThat(
+        getRegion(ProfileName.of("dev")),
+        equalTo(Region.US_EAST_1)
+    )
+
+    @Test
+    fun `custom profile has no region`() = assertThat(
+        getRegion(ProfileName.of("prod")),
+        absent()
+    )
+
+    @Test
+    fun `missing profile`() = assertThat(
+        getRegion(ProfileName.of("missing")),
+        absent()
+    )
+
+    @Test
+    fun `missing file`() = assertThat(
+        RegionProvider.Profile(Environment.EMPTY.with(AWS_CREDENTIAL_PROFILES_FILE of Path("foobar")))(),
+        absent()
+    )
+}

--- a/amazon/core/src/test/kotlin/org/http4k/connect/amazon/RegionProviderTest.kt
+++ b/amazon/core/src/test/kotlin/org/http4k/connect/amazon/RegionProviderTest.kt
@@ -1,0 +1,49 @@
+package org.http4k.connect.amazon
+
+import com.natpryce.hamkrest.absent
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.connect.amazon.core.model.Region
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.lang.IllegalArgumentException
+
+class RegionProviderTest {
+
+    @Test
+    fun `second element has region`() {
+        val chain = RegionProvider { null } orElse RegionProvider { Region.CA_CENTRAL_1 }
+
+        assertThat(
+            chain.invoke(),
+            equalTo(Region.CA_CENTRAL_1)
+        )
+    }
+
+    @Test
+    fun `first element has region`() {
+        val chain = RegionProvider { Region.US_EAST_1 } orElse RegionProvider { Region.CA_CENTRAL_1 }
+
+        assertThat(
+            chain.invoke(),
+            equalTo(Region.US_EAST_1)
+        )
+    }
+
+    @Test
+    fun `no element has region`() {
+        val chain = RegionProvider { null } orElse RegionProvider { null }
+
+        assertThat(
+            chain.invoke(),
+            absent()
+        )
+    }
+
+    @Test
+    fun `no element has region - thrown`() {
+        val chain = RegionProvider { null } orElse RegionProvider { null }
+
+        assertThrows<IllegalArgumentException>(chain::orElseThrow)
+    }
+}

--- a/amazon/instancemetadata/README.md
+++ b/amazon/instancemetadata/README.md
@@ -42,18 +42,63 @@ If the application is running inside an Amazon EC2 environment,
 this provider can authorize AWS requests using credentials from the instance profile.
 
 ```kotlin
-fun main() {    
+fun main() {
     // build a credentials provider that will attempt to load AWS credentials from the EC2's instance profile
     val credentialsProvider = CredentialsProvider.Ec2InstanceProfile()
-    
+
     // build a client that will authorize requests with the instance profile credentials
-    val s3 = S3.Http(credentialsProvider)
-    
+    val sns = SNS.Http(Region.US_EAST_1, credentialsProvider)
+
     // send a request
-    val buckets = s3.listBuckets().successValue()
-    println(buckets)
+    val topics = sns.listTopics()
+    println(topics)
 }
 ```
+
+:warning: The `Ec2InstanceProfile` provider should always be last in the chain,
+since it will time out if not in an Amazon EC2 environment.
+
+
+### Region Provider ###
+
+The Instance Metadata Service also offers a `RegionProvider`.
+If the application is running inside an Amazon EC2 environment,
+this provider can detect the current AWS region.
+
+```kotlin
+fun main() {
+    // we can connect to the real service or the fake (drop in replacement)
+    val imdsHttp: HttpHandler = if (USE_REAL_CLIENT) JavaHttpClient() else FakeInstanceMetadataService()
+    val snsHttp: HttpHandler = if (USE_REAL_CLIENT) JavaHttpClient() else FakeSNS()
+
+    /*
+     * Build a RegionProvider chain with the following steps:
+     * 1. Try to get region from AWS_REGION environment variable
+     * 2. Try to get region from profile credentials file
+     * 3. Try to get region from EC2 Instance Metadata Service
+     */
+    val regionProviderChain = RegionProvider.Environment(Environment.ENV) orElse
+        RegionProvider.Profile(Environment.ENV) orElse
+        RegionProvider.Ec2InstanceProfile(imdsHttp)
+
+    // Invoking the chain will return a region if one was found
+    val optionalRegion: Region? = regionProviderChain()
+    println(optionalRegion)
+
+    // orElseThrow will return a region or throw an exception if onr was not found
+    val region: Region = regionProviderChain.orElseThrow()
+    println(region)
+
+    // create and use an Amazon client with the resolved region
+    val sns = SNS.Http(region, { fakeAwsCredentials }, snsHttp)
+    val topics = sns.listTopics()
+    println(topics)
+}
+```
+
+:warning: The `Ec2InstanceProfile` provider should always be last in the chain,
+since it will time out if not in an Amazon EC2 environment.
+
 
 ### Default Fake port: 63407
 

--- a/amazon/instancemetadata/client/src/main/kotlin/org/http4k/connect/amazon/instancemetadata/Ec2InstanceProfileRegionProvider.kt
+++ b/amazon/instancemetadata/client/src/main/kotlin/org/http4k/connect/amazon/instancemetadata/Ec2InstanceProfileRegionProvider.kt
@@ -1,0 +1,16 @@
+package org.http4k.connect.amazon.instancemetadata
+
+import dev.forkhandles.result4k.valueOrNull
+import org.http4k.client.JavaHttpClient
+import org.http4k.connect.amazon.RegionProvider
+import org.http4k.core.HttpHandler
+
+/**
+ * This provider will time out if not in an EC2 Environment.
+ * For that reason, if there are multiple providers in a chain, this provider should be last.
+ */
+fun RegionProvider.Companion.Ec2InstanceProfile(ec2InstanceMetadata: InstanceMetadataService) =
+    RegionProvider { ec2InstanceMetadata.getInstanceIdentityDocument().valueOrNull()?.region }
+
+fun RegionProvider.Companion.Ec2InstanceProfile(http: HttpHandler = JavaHttpClient()) =
+    Ec2InstanceProfile(InstanceMetadataService.Http(http))

--- a/amazon/instancemetadata/fake/build.gradle.kts
+++ b/amazon/instancemetadata/fake/build.gradle.kts
@@ -1,4 +1,4 @@
 dependencies {
-    testImplementation(project(path = ":http4k-connect-amazon-s3"))
+    testImplementation(project(path = ":http4k-connect-amazon-sns-fake"))
     testImplementation(project(path = ":http4k-connect-amazon-core", configuration = "testArtifacts"))
 }

--- a/amazon/instancemetadata/fake/src/examples/kotlin/using_connect_client.kt
+++ b/amazon/instancemetadata/fake/src/examples/kotlin/using_connect_client.kt
@@ -7,7 +7,7 @@ import org.http4k.connect.amazon.instancemetadata.getLocalIpv4
 import org.http4k.core.HttpHandler
 import org.http4k.filter.debug
 
-const val USE_REAL_CLIENT = false
+private const val USE_REAL_CLIENT = false
 
 fun main() {
     // we can connect to the real service or the fake (drop in replacement)

--- a/amazon/instancemetadata/fake/src/examples/kotlin/using_credentials_provider.kt
+++ b/amazon/instancemetadata/fake/src/examples/kotlin/using_credentials_provider.kt
@@ -1,18 +1,18 @@
 import org.http4k.connect.amazon.CredentialsProvider
+import org.http4k.connect.amazon.core.model.Region
 import org.http4k.connect.amazon.instancemetadata.Ec2InstanceProfile
-import org.http4k.connect.amazon.s3.Http
-import org.http4k.connect.amazon.s3.S3
-import org.http4k.connect.amazon.s3.listBuckets
-import org.http4k.connect.successValue
+import org.http4k.connect.amazon.sns.Http
+import org.http4k.connect.amazon.sns.SNS
+import org.http4k.connect.amazon.sns.listTopics
 
 fun main() {
     // build a credentials provider that will attempt to load AWS credentials from the EC2's instance profile
     val credentialsProvider = CredentialsProvider.Ec2InstanceProfile()
 
     // build a client that will authorize requests with the instance profile credentials
-    val s3 = S3.Http(credentialsProvider)
+    val sns = SNS.Http(Region.US_EAST_1, credentialsProvider)
 
     // send a request
-    val buckets = s3.listBuckets().successValue()
-    println(buckets)
+    val topics = sns.listTopics()
+    println(topics)
 }

--- a/amazon/instancemetadata/fake/src/examples/kotlin/using_region_provider.kt
+++ b/amazon/instancemetadata/fake/src/examples/kotlin/using_region_provider.kt
@@ -1,0 +1,46 @@
+import org.http4k.aws.AwsCredentials
+import org.http4k.client.JavaHttpClient
+import org.http4k.cloudnative.env.Environment
+import org.http4k.connect.amazon.Environment
+import org.http4k.connect.amazon.Profile
+import org.http4k.connect.amazon.RegionProvider
+import org.http4k.connect.amazon.core.model.Region
+import org.http4k.connect.amazon.instancemetadata.Ec2InstanceProfile
+import org.http4k.connect.amazon.instancemetadata.FakeInstanceMetadataService
+import org.http4k.connect.amazon.sns.FakeSNS
+import org.http4k.connect.amazon.sns.Http
+import org.http4k.connect.amazon.sns.SNS
+import org.http4k.connect.amazon.sns.listTopics
+import org.http4k.core.HttpHandler
+
+private const val USE_REAL_CLIENT = false
+private val fakeAwsCredentials = AwsCredentials("fake", "fake")
+
+fun main() {
+    // we can connect to the real service or the fake (drop in replacement)
+    val imdsHttp: HttpHandler = if (USE_REAL_CLIENT) JavaHttpClient() else FakeInstanceMetadataService()
+    val snsHttp: HttpHandler = if (USE_REAL_CLIENT) JavaHttpClient() else FakeSNS()
+
+    /*
+     * Build a RegionProvider chain with the following steps:
+     * 1. Try to get region from AWS_REGION environment variable
+     * 2. Try to get region from profile credentials file
+     * 3. Try to get region from EC2 Instance Metadata Service
+     */
+    val regionProviderChain = RegionProvider.Environment(Environment.ENV) orElse
+        RegionProvider.Profile(Environment.ENV) orElse
+        RegionProvider.Ec2InstanceProfile(imdsHttp)
+
+    // Invoking the chain will return a region if one was found
+    val optionalRegion: Region? = regionProviderChain()
+    println(optionalRegion)
+
+    // orElseThrow will return a region or throw an exception if one was not found
+    val region: Region = regionProviderChain.orElseThrow()
+    println(region)
+
+    // create and use an Amazon client with the resolved region
+    val sns = SNS.Http(region, { fakeAwsCredentials }, snsHttp)
+    val topics = sns.listTopics()
+    println(topics)
+}

--- a/amazon/instancemetadata/fake/src/test/kotlin/org/http4k/connect/amazon/instancemetadata/Ec2InstanceProfileRegionProviderTest.kt
+++ b/amazon/instancemetadata/fake/src/test/kotlin/org/http4k/connect/amazon/instancemetadata/Ec2InstanceProfileRegionProviderTest.kt
@@ -1,0 +1,33 @@
+package org.http4k.connect.amazon.instancemetadata
+
+import com.natpryce.hamkrest.absent
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.connect.amazon.RegionProvider
+import org.http4k.connect.amazon.core.model.Region
+import org.http4k.core.Status
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+class Ec2InstanceProfileRegionProviderTest {
+
+    private val clock = Clock.fixed(Instant.parse("2022-03-04T12:00:00Z"), ZoneOffset.UTC)
+    private val metadata = InstanceMetadata(clock.instant(), region = Region.CA_CENTRAL_1)
+    private val service = FakeInstanceMetadataService(clock, metadata)
+    private val provider = RegionProvider.Ec2InstanceProfile(service)
+
+    @Test
+    fun `metadata service not available (not in EC2)`() {
+        service.returnStatus(Status.CONNECTION_REFUSED)
+
+        assertThat(provider.invoke(), absent())
+    }
+
+    @Test
+    fun `load region from instance profile`() = assertThat(
+        provider.invoke(),
+        equalTo(Region.CA_CENTRAL_1)
+    )
+}


### PR DESCRIPTION
So far, I've decided to leave the client builders untouched.  The region provider can easily calculate the region to be passed in to the existing builder functions.  See the `using_region_provider.kt` example.