### PR TITLE
Dynamodb query scan pagination

### DIFF
--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/action/Scan.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/action/Scan.kt
@@ -3,6 +3,7 @@ package org.http4k.connect.amazon.dynamodb.action
 import org.http4k.connect.Http4kConnectAction
 import org.http4k.connect.Paged
 import org.http4k.connect.amazon.dynamodb.model.ConsumedCapacity
+import org.http4k.connect.amazon.dynamodb.model.IndexName
 import org.http4k.connect.amazon.dynamodb.model.Item
 import org.http4k.connect.amazon.dynamodb.model.ItemResult
 import org.http4k.connect.amazon.dynamodb.model.Key
@@ -23,7 +24,7 @@ data class Scan(
     val ExpressionAttributeNames: TokensToNames? = null,
     val ExpressionAttributeValues: TokensToValues? = null,
     val ExclusiveStartKey: Key? = null,
-    val IndexName: String? = null,
+    val IndexName: IndexName? = null,
     override val Limit: Int? = null,
     val ConsistentRead: Boolean? = null,
     val Segment: Int? = null,

--- a/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/DynamoTable.kt
+++ b/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/DynamoTable.kt
@@ -1,27 +1,18 @@
 package org.http4k.connect.amazon.dynamodb
 
-import org.http4k.connect.amazon.dynamodb.endpoints.keySchema
+import org.http4k.connect.amazon.dynamodb.endpoints.key
 import org.http4k.connect.amazon.dynamodb.model.Item
 import org.http4k.connect.amazon.dynamodb.model.Key
 import org.http4k.connect.amazon.dynamodb.model.TableDescription
 
-data class DynamoTable(val table: TableDescription, val items: List<Item> = emptyList()) {
+data class DynamoTable(val table: TableDescription, val items: List<Item> = emptyList(), val maxPageSize: Int = 1_000) {
     fun retrieve(key: Key) = items.firstOrNull { it.matches(key) }
 
-    fun withItem(item: Item) = retrieve(item.key())
+    fun withItem(item: Item) = retrieve(item.key(table))
         .let { existing -> if (existing != null) withoutItem(existing) else this }
         .let { it.copy(items = it.items + item) }
 
-    fun withoutItem(key: Key) = copy(items = items.filterNot { it.matches(key) })
-
     private fun Item.matches(key: Key) = toList().containsAll(key.toList())
 
-    private fun Item.key(): Key {
-        val schema = keySchema() ?: error("No key defined!")
-
-        return schema.mapNotNull { key ->
-            val value = this[key.AttributeName]
-            if (value == null) null else key.AttributeName to value
-        }.toMap()
-    }
+    fun withoutItem(key: Key) = copy(items = items.filterNot { it.matches(key) })
 }

--- a/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/DynamoTable.kt
+++ b/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/DynamoTable.kt
@@ -12,7 +12,7 @@ data class DynamoTable(val table: TableDescription, val items: List<Item> = empt
         .let { existing -> if (existing != null) withoutItem(existing) else this }
         .let { it.copy(items = it.items + item) }
 
-    private fun Item.matches(key: Key) = toList().containsAll(key.toList())
-
     fun withoutItem(key: Key) = copy(items = items.filterNot { it.matches(key) })
+
+    private fun Item.matches(key: Key) = toList().containsAll(key.toList())
 }

--- a/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/helpers.kt
+++ b/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/helpers.kt
@@ -11,7 +11,10 @@ import org.http4k.connect.amazon.dynamodb.model.AttributeName
 import org.http4k.connect.amazon.dynamodb.model.AttributeValue
 import org.http4k.connect.amazon.dynamodb.model.IndexName
 import org.http4k.connect.amazon.dynamodb.model.Item
+import org.http4k.connect.amazon.dynamodb.model.Key
 import org.http4k.connect.amazon.dynamodb.model.KeySchema
+import org.http4k.connect.amazon.dynamodb.model.KeyType
+import org.http4k.connect.amazon.dynamodb.model.TableDescription
 import org.http4k.connect.amazon.dynamodb.model.TokensToNames
 import org.http4k.connect.amazon.dynamodb.model.TokensToValues
 import kotlin.Comparator
@@ -85,29 +88,51 @@ fun Item.update(
         }
 }
 
-fun AttributeName?.comparator(ascending: Boolean): Comparator<Item> = object: Comparator<Item> {
-    val attributeName = this@comparator
+fun List<KeySchema>?.comparator(ascending: Boolean): Comparator<Item> {
+    if (this == null) return Comparator { _, _ -> 0 }
+
+    val hashKey = find { it.KeyType == KeyType.HASH }
+        ?.AttributeName
+        ?: return Comparator { _, _ -> 0 }
+
+    val sortKey = find { it.KeyType == KeyType.RANGE }
+        ?.AttributeName
     val modifier = if (ascending) 1 else -1
 
-    override fun compare(item1: Item, item2: Item): Int {
-        if (attributeName == null) return 0
-        val value1 = item1[attributeName] ?: return 0
-        val value2 = item2[attributeName] ?: return 0
+    return Comparator { item1: Item, item2: Item ->
+        val hashValue1 = item1[hashKey] ?: return@Comparator 0
+        val hashValue2 = item2[hashKey] ?: return@Comparator 0
 
-        return value1.compareTo(value2) * modifier
+        val hashComparison = hashValue1.compareTo(hashValue2) * modifier
+        if (hashComparison != 0) return@Comparator hashComparison
+
+        val sortValue1 = item1[sortKey] ?: return@Comparator 0
+        val sortValue2 = item2[sortKey] ?: return@Comparator 0
+
+        sortValue1.compareTo(sortValue2) * modifier
     }
+
 }
 
-fun DynamoTable.keySchema(indexName: IndexName? = null): List<KeySchema>? {
-    if (indexName == null) return table.KeySchema
+fun TableDescription.keySchema(indexName: IndexName? = null): List<KeySchema>? {
+    if (indexName == null) return KeySchema
 
-    for (index in table.GlobalSecondaryIndexes ?: emptyList()) {
+    for (index in GlobalSecondaryIndexes ?: emptyList()) {
         if (index.IndexName == indexName.value) {
             return index.KeySchema
         }
     }
 
-    return table.LocalSecondaryIndexes
+    return LocalSecondaryIndexes
         ?.find { it.IndexName == indexName.value }
         ?.KeySchema
+}
+
+fun Item.key(table: TableDescription): Key {
+    val schema = table.keySchema() ?: error("No key defined!")
+
+    return schema.mapNotNull { key ->
+        val value = this[key.AttributeName]
+        if (value == null) null else key.AttributeName to value
+    }.toMap()
 }

--- a/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/query.kt
+++ b/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/query.kt
@@ -4,18 +4,15 @@ import org.http4k.connect.amazon.AmazonJsonFake
 import org.http4k.connect.amazon.dynamodb.DynamoTable
 import org.http4k.connect.amazon.dynamodb.action.Query
 import org.http4k.connect.amazon.dynamodb.action.QueryResponse
-import org.http4k.connect.amazon.dynamodb.model.KeyType
 import org.http4k.connect.storage.Storage
 
 fun AmazonJsonFake.query(tables: Storage<DynamoTable>) = route<Query> { query ->
     val table = tables[query.TableName.value] ?: return@route null
 
-    val comparator = table.keySchema(query.IndexName)
-        ?.find { it.KeyType == KeyType.RANGE }
-        ?.AttributeName
+    val comparator = table.table.keySchema(query.IndexName)
         .comparator(query.ScanIndexForward ?: true)
 
-    val items = table.items
+    val matches = table.items
         .asSequence()
         .mapNotNull {it.condition(
             expression = query.KeyConditionExpression,
@@ -28,13 +25,17 @@ fun AmazonJsonFake.query(tables: Storage<DynamoTable>) = route<Query> { query ->
             expressionAttributeValues = query.ExpressionAttributeValues
         ) }
         .sortedWith(comparator)
-        .map { it.asItemResult() }
-        .take(query.Limit ?: Int.MAX_VALUE)
-        .toList()  // TODO pagination
+        .dropWhile { query.ExclusiveStartKey != null && comparator.compare(it, query.ExclusiveStartKey!!) <= 0 }
+        .toList()
+
+    val page = matches.take((query.Limit ?: table.maxPageSize).coerceAtMost(table.maxPageSize))
 
     QueryResponse(
-        Count = items.size,
-        Items = items
+        Count = page.size,
+        Items = page.map { it.asItemResult() },
+        LastEvaluatedKey = if (page.size < matches.size) {
+            page.lastOrNull()?.key(table.table)
+        } else null
     )
 }
 

--- a/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/scan.kt
+++ b/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/scan.kt
@@ -9,19 +9,26 @@ import org.http4k.connect.storage.Storage
 fun AmazonJsonFake.scan(tables: Storage<DynamoTable>) = route<Scan> { scan ->
     val table = tables[scan.TableName.value] ?: return@route null
 
-    val items = table.items
+    val comparator = table.table.keySchema(scan.IndexName).comparator(true)
+
+    val matches = table.items
         .asSequence()
         .mapNotNull {it.condition(
             expression = scan.FilterExpression,
             expressionAttributeNames = scan.ExpressionAttributeNames,
             expressionAttributeValues = scan.ExpressionAttributeValues
         ) }
-        .map { it.asItemResult() }
-        .take(scan.Limit ?: Int.MAX_VALUE)
+        .sortedWith(comparator)
+        .dropWhile { scan.ExclusiveStartKey != null && comparator.compare(it, scan.ExclusiveStartKey!!) <= 0 }
         .toList()
 
+    val page = matches.take((scan.Limit ?: table.maxPageSize).coerceAtMost(table.maxPageSize))
+
     ScanResponse(
-        Count = items.size,
-        Items = items
+        Count = page.size,
+        Items = page.map { it.asItemResult() },
+        LastEvaluatedKey = if (page.size < matches.size) {
+            page.lastOrNull()?.key(table.table)
+        } else null
     )
 }


### PR DESCRIPTION
I couldn't _feasibly_ replicate the actual DynamoDB pagination rules (page size of 1 MB), so the fake table has a default limit of 1000 items.  The contract shared by the local and fake implementations is generic enough to ensure page sizes are _roughly_ honoured by both.

For scan, pagination is a little odd, because there's no explicitly defined order for the rows.  Even though the local implementations' ordering seems deterministic, I'm not sure what the algorithm actually is.  So what I've done is have the fake scan apply ordering based on the the index in use, and paginate based on that.  Due to this, the contract will not expect a specific `lastEvaluatedKey` or `items` in each page; it will instead ensure it can use the pagination controls to reach the end.

Closes #232 