### PR TITLE
DynamoDB Index Mapper Argument Tweaks

### DIFF
--- a/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbTableMapperTest.kt
+++ b/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbTableMapperTest.kt
@@ -95,7 +95,7 @@ class DynamoDbTableMapperTest {
     @Test
     fun `query for index - reverse order`() {
         assertThat(
-            tableMapper.index(byOwner).query(owner2, scanIndexForward = false).toList(),
+            tableMapper.index(byOwner).query(owner2, ScanIndexForward = false).toList(),
             equalTo(listOf(smokie, bandit))
         )
     }
@@ -144,8 +144,8 @@ class DynamoDbTableMapperTest {
     @Test
     fun `custom query`() {
         val results = tableMapper.index(byDob).query(
-            filter = "$bornAttr = :val1",
-            values = mapOf(":val1" to bornAttr.asValue(smokie.born))
+            KeyConditionExpression = "$bornAttr = :val1",
+            ExpressionAttributeValues = mapOf(":val1" to bornAttr.asValue(smokie.born))
         ).toList()
 
         assertThat(results, equalTo(listOf(smokie, bandit)))
@@ -154,14 +154,14 @@ class DynamoDbTableMapperTest {
     @Test
     fun `query page`() {
         // page 1 of 2
-        assertThat(tableMapper.index(byOwner).queryPage(owner1, limit = 2), equalTo(DynamoDbPage(
+        assertThat(tableMapper.index(byOwner).queryPage(owner1, Limit = 2), equalTo(DynamoDbPage(
             items = listOf(athena, kratos),
             nextHashKey = owner1,
             nextSortKey = kratos.name
         )))
 
         // page 2 of 2
-        assertThat(tableMapper.index(byOwner).queryPage(owner1, limit = 2, exclusiveStartKey = kratos.name), equalTo(DynamoDbPage(
+        assertThat(tableMapper.index(byOwner).queryPage(owner1, Limit = 2, ExclusiveStartKey = kratos.name), equalTo(DynamoDbPage(
             items = listOf(toggles),
             nextHashKey = null,
             nextSortKey = null
@@ -171,14 +171,14 @@ class DynamoDbTableMapperTest {
     @Test
     fun `scan page - secondary index`() {
         // page 1 of 1
-        assertThat(tableMapper.index(byOwner).scanPage(limit = 3), equalTo(DynamoDbPage(
+        assertThat(tableMapper.index(byOwner).scanPage(Limit = 3), equalTo(DynamoDbPage(
             items = listOf(bandit, smokie, athena),
             nextHashKey = owner1,
             nextSortKey = athena.name
         )))
 
         // page 2 of 2
-        assertThat(tableMapper.index(byOwner).scanPage(limit = 3, exclusiveStartKey = owner1 to athena.name), equalTo(DynamoDbPage(
+        assertThat(tableMapper.index(byOwner).scanPage(Limit = 3, ExclusiveStartKey = owner1 to athena.name), equalTo(DynamoDbPage(
             items = listOf(kratos, toggles),
             nextHashKey = null,
             nextSortKey = null
@@ -188,14 +188,14 @@ class DynamoDbTableMapperTest {
     @Test
     fun `scan page - primary index with no sort key`() {
         // page 1 of 1
-        assertThat(tableMapper.primaryIndex().scanPage(limit = 3), equalTo(DynamoDbPage(
+        assertThat(tableMapper.primaryIndex().scanPage(Limit = 3), equalTo(DynamoDbPage(
             items = listOf(smokie, kratos, bandit),
             nextHashKey = bandit.id,
             nextSortKey = null
         )))
 
         // page 2 of 2
-        assertThat(tableMapper.primaryIndex().scanPage(limit = 3, exclusiveStartKey = bandit.id to null), equalTo(DynamoDbPage(
+        assertThat(tableMapper.primaryIndex().scanPage(Limit = 3, ExclusiveStartKey = bandit.id to null), equalTo(DynamoDbPage(
             items = listOf(toggles, athena),
             nextHashKey = null,
             nextSortKey = null


### PR DESCRIPTION
There's a few things happening here, and some of them are breaking:

- The index mapper `query` operation incorrectly exposed a `filter` argument, when it was actually the key condition expression; this has been corrected
- tweaked the index mapper argument casing to be more consistent with the rest of the library; can undo to reduce breaking changes
- Exposed some additional optional arguments to the index mapper