### PR TITLE
fake dynamodb to support putItem conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ changes with their rationale when appropriate. Given version `A.B.C.D`, breaking
 
 ### v5.1.3.0 (Uncut)
 - **http4k-connect-amazon-dynamodb** - Add scanPage and queryPage operations to DynamoDb table mapper. Pagination can now be controlled by the caller. H/T @oharaandrew314
+- **http4k-connect-amazon-dynamodb-fake** - putItem not supports a `ConditionExpression`.
 - **http4k-connect-amazon-dynamodb-fake** - [Fix] query and scan will now return the correct LastEvaluatedKey based on the current index. H/T @oharaandrew314
+- **http4k-connect-amazon-dynamodb-fake** - [Fix] Condition Expressions now support name substitutions in the `attribute_exists` and `attribute_not_exists` functions
 
 ### v5.1.2.0
 - **http4k-connect-amazon-eventbridge** - [New module] Adapter and fake implementation.

--- a/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/putItem.kt
+++ b/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/putItem.kt
@@ -13,17 +13,14 @@ fun AmazonJsonFake.putItem(tables: Storage<DynamoTable>) = route<PutItem> { req 
     if (req.ConditionExpression != null) {
         val existing = table.retrieve(req.Item.key(table.table.KeySchema!!))
         if (existing != null) {
-            val matches = existing.condition(
+            existing.condition(
                 expression = req.ConditionExpression,
                 expressionAttributeNames = req.ExpressionAttributeNames,
                 expressionAttributeValues = req.ExpressionAttributeValues
-            ) != null
-            if (!matches) {
-                return@route JsonError(
-                    "com.amazonaws.dynamodb.v20120810#ConditionalCheckFailedException",
-                    "The conditional request failed"
-                )
-            }
+            ) ?: return@route JsonError(
+                "com.amazonaws.dynamodb.v20120810#ConditionalCheckFailedException",
+                "The conditional request failed"
+            )
         }
     }
 

--- a/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/putItem.kt
+++ b/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/putItem.kt
@@ -1,16 +1,34 @@
 package org.http4k.connect.amazon.dynamodb.endpoints
 
 import org.http4k.connect.amazon.AmazonJsonFake
+import org.http4k.connect.amazon.JsonError
 import org.http4k.connect.amazon.dynamodb.DynamoTable
 import org.http4k.connect.amazon.dynamodb.action.ModifiedItem
 import org.http4k.connect.amazon.dynamodb.action.PutItem
 import org.http4k.connect.storage.Storage
 
-fun AmazonJsonFake.putItem(tables: Storage<DynamoTable>) = route<PutItem> {
-    tables[it.TableName.value]
-        ?.let { table ->
-            tables[it.TableName.value] = table.withItem(it.Item)
-            ModifiedItem(it.Item.asItemResult())
+fun AmazonJsonFake.putItem(tables: Storage<DynamoTable>) = route<PutItem> { req ->
+    val table = tables[req.TableName.value] ?: return@route null
+
+    if (req.ConditionExpression != null) {
+        val existing = table.retrieve(req.Item.key(table.table.KeySchema!!))
+        if (existing != null) {
+            val matches = existing.condition(
+                expression = req.ConditionExpression,
+                expressionAttributeNames = req.ExpressionAttributeNames,
+                expressionAttributeValues = req.ExpressionAttributeValues
+            ) != null
+            if (!matches) {
+                return@route JsonError(
+                    "com.amazonaws.dynamodb.v20120810#ConditionalCheckFailedException",
+                    "The conditional request failed"
+                )
+            }
         }
+    }
+
+    tables[req.TableName.value] = table.withItem(req.Item)
+    ModifiedItem(req.Item.asItemResult())
+
     Unit
 }

--- a/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/grammar/AttributeExists.kt
+++ b/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/grammar/AttributeExists.kt
@@ -1,20 +1,20 @@
 package org.http4k.connect.amazon.dynamodb.grammar
 
-import org.http4k.connect.amazon.dynamodb.model.AttributeName
+import org.http4k.connect.amazon.dynamodb.model.AttributeValue
 import parser4k.Parser
-import parser4k.commonparsers.Tokens
 import parser4k.commonparsers.token
 import parser4k.inOrder
 import parser4k.map
+import parser4k.ref
 import parser4k.skipWrapper
 
 object AttributeExists : ExprFactory {
     override operator fun invoke(parser: () -> Parser<Expr>) =
-        inOrder(token("attribute_exists"), token("("), Tokens.identifier, token(")"))
+        inOrder(token("attribute_exists"), token("("), ref(parser), token(")"))
             .skipWrapper()
-            .map { (_, name) ->
+            .map { (_, attr) ->
                 Expr {
-                    it.item.containsKey(AttributeName.of(name))
+                    (attr.eval(it) as AttributeValue).NULL == null
                 }
             }
 }

--- a/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/grammar/AttributeNotExists.kt
+++ b/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/grammar/AttributeNotExists.kt
@@ -1,20 +1,20 @@
 package org.http4k.connect.amazon.dynamodb.grammar
 
-import org.http4k.connect.amazon.dynamodb.model.AttributeName
+import org.http4k.connect.amazon.dynamodb.model.AttributeValue
 import parser4k.Parser
-import parser4k.commonparsers.Tokens
 import parser4k.commonparsers.token
 import parser4k.inOrder
 import parser4k.map
+import parser4k.ref
 import parser4k.skipWrapper
 
 object AttributeNotExists : ExprFactory {
     override operator fun invoke(parser: () -> Parser<Expr>) =
-        inOrder(token("attribute_not_exists"), token("("), Tokens.identifier, token(")"))
+        inOrder(token("attribute_not_exists"), token("("), ref(parser), token(")"))
             .skipWrapper()
-            .map { (_, name) ->
+            .map { (_, attr) ->
                 Expr {
-                    !it.item.containsKey(AttributeName.of(name))
+                    (attr.eval(it) as AttributeValue).NULL == true
                 }
             }
 }

--- a/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/grammar/DynamoDbConditionalGrammarTest.kt
+++ b/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/grammar/DynamoDbConditionalGrammarTest.kt
@@ -99,6 +99,13 @@ class DynamoDbConditionalGrammarTest {
     }
 
     @Test
+    fun `attribute exists - substitution of names`() {
+        val item = Item(attr1 of "123")
+        assertTrue("attribute_exists(#key1)", item, names = mapOf("#key1" to attr1.name))
+        assertFalse("attribute_exists(#key1)", item, names = mapOf("#key1" to attr2.name))
+    }
+
+    @Test
     fun `attribute value`() {
         assertThat(
             DynamoDbConditionalGrammar.parse("attr1").eval(ItemWithSubstitutions(Item(attr1 of "123"))),
@@ -226,6 +233,13 @@ class DynamoDbConditionalGrammarTest {
         val item = Item(attr1 of "123")
         assertTrue("attribute_not_exists(attr2)", item)
         assertFalse("attribute_not_exists(attr1)", item)
+    }
+
+    @Test
+    fun `attributes not exists - substitution of names`() {
+        val item = Item(attr1 of "123")
+        assertTrue("attribute_not_exists(#key1)", item, names = mapOf("#key1" to attr2.name))
+        assertFalse("attribute_not_exists(#key1)", item, names = mapOf("#key1" to attr1.name))
     }
 
     @Test


### PR DESCRIPTION
Closes #272 

Fake DynamoDB will now support a `ConditionExpression` for `putItem`.
I also discovered a parser bug where `attribute_exists` and `attribute_not_exists` would not accept a name substitution parameter. 