### PR TITLE
Add ConfirmForgotPassword to Cognito

### DIFF
--- a/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/ConfirmForgotPassword.kt
+++ b/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/ConfirmForgotPassword.kt
@@ -1,0 +1,36 @@
+package org.http4k.connect.amazon.cognito.action
+
+import dev.forkhandles.result4k.Failure
+import dev.forkhandles.result4k.Success
+import org.http4k.connect.Http4kConnectAction
+import org.http4k.connect.amazon.cognito.CognitoAction
+import org.http4k.connect.amazon.cognito.model.AnalyticsMetadata
+import org.http4k.connect.amazon.cognito.model.ClientId
+import org.http4k.connect.amazon.cognito.model.ConfirmationCode
+import org.http4k.connect.amazon.cognito.model.SecretHash
+import org.http4k.connect.amazon.cognito.model.UserContextData
+import org.http4k.connect.amazon.core.model.Password
+import org.http4k.connect.amazon.core.model.Username
+import org.http4k.connect.asRemoteFailure
+import org.http4k.core.Response
+import se.ansman.kotshi.JsonSerializable
+
+@Http4kConnectAction
+@JsonSerializable
+data class ConfirmForgotPassword(
+    val ClientId: ClientId,
+    val Username: Username,
+    val ConfirmationCode: ConfirmationCode,
+    val Password: Password,
+    val SecretHash: SecretHash? = null,
+    val ClientMetadata: Map<String, String> = emptyMap(),
+    val AnalyticsMetadata: AnalyticsMetadata? = null,
+    val UserContextData: UserContextData? = null
+) : CognitoAction<Unit>(Unit::class) {
+    override fun toResult(response: Response) = with(response) {
+        when {
+            status.successful -> Success(Unit)
+            else -> Failure(asRemoteFailure(this))
+        }
+    }
+}

--- a/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/model/cognito.kt
+++ b/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/model/cognito.kt
@@ -62,6 +62,14 @@ class SecretCode private constructor(value: String) : StringValue(value) {
     companion object : NonBlankStringValueFactory<SecretCode>(::SecretCode)
 }
 
+class ConfirmationCode private constructor(value: String) : StringValue(value) {
+    companion object : NonBlankStringValueFactory<ConfirmationCode>(::ConfirmationCode)
+}
+
+class SecretHash private constructor(value: String) : StringValue(value) {
+    companion object : NonBlankStringValueFactory<SecretHash>(::SecretHash)
+}
+
 data class NewDeviceMetadata(
     val DeviceGroupKey: String? = null,
     val DeviceKey: String? = null


### PR DESCRIPTION
Without an update to the fake I'm afraid, as the interactions around AdminResetUserPassword, timeouts etc are just too horrible.

I'm not entirely convinced that the new SecretHash is not the same as the exisiting SecretCode, but I think that they are different.