### PR TITLE
eliminate ini4j

### DIFF
--- a/amazon/core/build.gradle.kts
+++ b/amazon/core/build.gradle.kts
@@ -7,5 +7,4 @@ dependencies {
 
     implementation(Libs.api)
     implementation(Libs.http4k_format_core)
-    implementation(libs.ini4j)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,8 +54,6 @@ symbol-processing-api = "com.google.devtools.ksp:symbol-processing-api:_"
 
 se-ansman-kotshi-compiler = "se.ansman.kotshi:compiler:_"
 
-ini4j = "org.ini4j:ini4j:_"
-
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
 
 parser4k = { module = "dev.forkhandles:parser4k" }

--- a/versions.properties
+++ b/versions.properties
@@ -53,8 +53,6 @@ version.org.bitbucket.b_c..jose4j=0.9.3
 
 version.org.bouncycastle..bcprov-jdk18on=1.76
 
-version.org.ini4j..ini4j=0.5.4
-
 version.kotlinpoet=1.14.2
 
 # blocked - Java 8 - 1.13.8


### PR DESCRIPTION
Manually parsing the AWS credentials file will allow us to eliminate ini4j.

Technically, I could have used the existing `Environment.fromConfigFile` to parse the ini, but it wouldn't have been returned in a format easy to consume in the way I needed.