### PR TITLE
Add query builder to DynamoDbIndexMapper query functions

### DIFF
--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbIndexMapper.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbIndexMapper.kt
@@ -13,8 +13,8 @@ class DynamoDbIndexMapper<Document: Any, HashKey: Any, SortKey: Any>(
 ) {
     fun scan(
         FilterExpression: String? = null,
-        ExpressionAttributeNames: Map<String, AttributeName>? = null,
-        ExpressionAttributeValues: Map<String, AttributeValue>? = null,
+        ExpressionAttributeNames: TokensToNames? = null,
+        ExpressionAttributeValues: TokensToValues? = null,
         PageSize: Int? = null,
         ConsistentRead: Boolean? = null,
     ): Sequence<Document> {
@@ -32,8 +32,8 @@ class DynamoDbIndexMapper<Document: Any, HashKey: Any, SortKey: Any>(
 
     fun scanPage(
         FilterExpression: String? = null,
-        ExpressionAttributeNames: Map<String, AttributeName>? = null,
-        ExpressionAttributeValues: Map<String, AttributeValue>? = null,
+        ExpressionAttributeNames: TokensToNames? = null,
+        ExpressionAttributeValues: TokensToValues? = null,
         ExclusiveStartKey: Pair<HashKey, SortKey?>? = null,
         Limit: Int? = null,
         ConsistentRead: Boolean? = null,
@@ -59,8 +59,8 @@ class DynamoDbIndexMapper<Document: Any, HashKey: Any, SortKey: Any>(
     fun query(
         KeyConditionExpression: String? = null,
         FilterExpression: String? = null,
-        ExpressionAttributeNames: Map<String, AttributeName>? = null,
-        ExpressionAttributeValues: Map<String, AttributeValue>? = null,
+        ExpressionAttributeNames: TokensToNames? = null,
+        ExpressionAttributeValues: TokensToValues? = null,
         ScanIndexForward: Boolean = true,
         PageSize: Int? = null,
         ConsistentRead: Boolean? = null,
@@ -97,20 +97,29 @@ class DynamoDbIndexMapper<Document: Any, HashKey: Any, SortKey: Any>(
     }
 
     fun queryPage(
-        HashKey: HashKey,
+        KeyConditionExpression: String? = null,
+        FilterExpression: String? = null,
+        ExpressionAttributeNames: TokensToNames? = null,
+        ExpressionAttributeValues: TokensToValues? = null,
+        ExclusiveStartHashKey: HashKey? = null,
+        ExclusiveStartSortKey: SortKey? = null,
         ScanIndexForward: Boolean = true,
-        ExclusiveStartKey: SortKey? = null,
         Limit: Int? = null,
         ConsistentRead: Boolean? = null,
     ): DynamoDbPage<Document, HashKey, SortKey> {
         val page = dynamoDb.query(
             TableName = tableName,
             IndexName = schema.indexName,
-            KeyConditionExpression = "#key1 = :val1",
-            ExpressionAttributeNames = mapOf("#key1" to schema.hashKeyAttribute.name),
-            ExpressionAttributeValues = mapOf(":val1" to schema.hashKeyAttribute.asValue(HashKey)),
+            KeyConditionExpression = KeyConditionExpression,
+            ExpressionAttributeNames = ExpressionAttributeNames,
+            ExpressionAttributeValues = ExpressionAttributeValues,
+            FilterExpression = FilterExpression,
             ScanIndexForward = ScanIndexForward,
-            ExclusiveStartKey = ExclusiveStartKey?.let { schema.key(HashKey, ExclusiveStartKey) },
+            ExclusiveStartKey = ExclusiveStartHashKey?.let {
+                ExclusiveStartSortKey?.let {
+                    schema.key(ExclusiveStartHashKey, ExclusiveStartSortKey)
+                }
+            },
             Limit = Limit,
             ConsistentRead = ConsistentRead
         ).onFailure { it.reason.throwIt() }
@@ -121,4 +130,21 @@ class DynamoDbIndexMapper<Document: Any, HashKey: Any, SortKey: Any>(
             nextSortKey = page.LastEvaluatedKey?.let { key -> schema.sortKeyAttribute?.let { attr -> attr[key] } }
         )
     }
+
+    fun queryPage(
+        HashKey: HashKey,
+        ScanIndexForward: Boolean = true,
+        ExclusiveStartKey: SortKey? = null,
+        Limit: Int? = null,
+        ConsistentRead: Boolean? = null,
+    ): DynamoDbPage<Document, HashKey, SortKey> = queryPage(
+        KeyConditionExpression = "#key1 = :val1",
+        ExpressionAttributeNames = mapOf("#key1" to schema.hashKeyAttribute.name),
+        ExpressionAttributeValues = mapOf(":val1" to schema.hashKeyAttribute.asValue(HashKey)),
+        ScanIndexForward = ScanIndexForward,
+        ExclusiveStartHashKey = HashKey,
+        ExclusiveStartSortKey = ExclusiveStartKey,
+        Limit = Limit,
+        ConsistentRead = ConsistentRead
+    )
 }

--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryBuilder.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryBuilder.kt
@@ -1,0 +1,286 @@
+package org.http4k.connect.amazon.dynamodb.mapper
+
+import org.http4k.connect.amazon.dynamodb.model.Attribute
+import org.http4k.connect.amazon.dynamodb.model.AttributeName
+import org.http4k.connect.amazon.dynamodb.model.AttributeValue
+
+internal class DynamoDbQuery(
+    val keyConditionExpression: String?,
+    val filterExpression: String?,
+    val expressionAttributeNames: Map<String, AttributeName>?,
+    val expressionAttributeValues: Map<String, AttributeValue>?,
+    val scanIndexForward: Boolean,
+    val pageSize: Int?,
+    val consistentRead: Boolean?
+)
+
+interface KeyCondition {
+    val expression: String
+    val attributeNames: Map<String, AttributeName>
+    val attributeValues: Map<String, AttributeValue>
+}
+
+interface SortKeyCondition : KeyCondition
+interface CombinedKeyCondition : KeyCondition
+interface PartitionKeyCondition : SortKeyCondition, CombinedKeyCondition
+
+class FilterExpression(
+    val expression: String,
+    val attributeNames: Map<String, AttributeName>,
+    val attributeValues: Map<String, AttributeValue>
+)
+
+class DynamoDbQueryBuilder {
+
+    /**
+     * See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.KeyConditionExpressions.html
+     */
+    inner class KeyConditionBuilder {
+
+        infix fun <T> Attribute<T>.eq(value: T) = nextAttributeName().let { attributeName ->
+            object : PartitionKeyCondition {
+                override val expression = "#$attributeName = :$attributeName"
+                override val attributeNames = mapOf("#$attributeName" to name)
+                override val attributeValues = mapOf(":$attributeName" to asValue(value))
+            }
+        }
+
+        private fun sortKeyCondition(
+            expr: String,
+            attrNames: Map<String, AttributeName>,
+            attrValues: Map<String, AttributeValue>
+        ) = object : SortKeyCondition {
+            override val expression = expr
+            override val attributeNames = attrNames
+            override val attributeValues = attrValues
+        }
+
+        private fun <T> Attribute<T>.sortKeyOperator(op: String, value: T) = nextAttributeName().let { attributeName ->
+            sortKeyCondition(
+                "#$attributeName $op :$attributeName",
+                mapOf("#$attributeName" to name),
+                mapOf(":$attributeName" to asValue(value))
+            )
+        }
+
+        infix fun <T> Attribute<T>.lt(value: T) = sortKeyOperator("<", value)
+        infix fun <T> Attribute<T>.le(value: T) = sortKeyOperator("<=", value)
+        infix fun <T> Attribute<T>.gt(value: T) = sortKeyOperator(">", value)
+        infix fun <T> Attribute<T>.ge(value: T) = sortKeyOperator(">=", value)
+
+        fun <T> between(attr: Attribute<T>, value1: T, value2: T) = nextAttributeName().let { attributeName ->
+            sortKeyCondition(
+                "#$attributeName BETWEEN :${attributeName}1 AND :${attributeName}2",
+                mapOf("#$attributeName" to attr.name),
+                mapOf(":${attributeName}1" to attr.asValue(value1), ":${attributeName}2" to attr.asValue(value2))
+            )
+        }
+
+        infix fun <T> Attribute<T>.beginsWith(value: T) = nextAttributeName().let { attributeName ->
+            sortKeyCondition(
+                "begins_with(#$attributeName,:$attributeName)",
+                mapOf("#$attributeName" to name),
+                mapOf(":$attributeName" to asValue(value))
+            )
+        }
+
+        infix fun PartitionKeyCondition.and(secondary: SortKeyCondition?): CombinedKeyCondition = let {
+            if (secondary == null) {
+                this
+            } else {
+                object : CombinedKeyCondition {
+                    override val expression = "${it.expression} AND ${secondary.expression}"
+                    override val attributeNames = it.attributeNames + secondary.attributeNames
+                    override val attributeValues = it.attributeValues + secondary.attributeValues
+                }
+            }
+        }
+    }
+
+    /**
+     * See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Syntax
+     */
+    inner class FilterExpressionBuilder {
+
+        private fun <T> Attribute<T>.filterOperator(op: String, value: T) = nextAttributeName().let { attributeName ->
+            FilterExpression(
+                "#$attributeName $op :$attributeName",
+                mapOf("#$attributeName" to name),
+                mapOf(":$attributeName" to asValue(value))
+            )
+        }
+
+        infix fun <T> Attribute<T>.eq(value: T) = filterOperator("=", value)
+        infix fun <T> Attribute<T>.ne(value: T) = filterOperator("<>", value)
+        infix fun <T> Attribute<T>.lt(value: T) = filterOperator("<", value)
+        infix fun <T> Attribute<T>.le(value: T) = filterOperator("<=", value)
+        infix fun <T> Attribute<T>.gt(value: T) = filterOperator(">", value)
+        infix fun <T> Attribute<T>.ge(value: T) = filterOperator(">=", value)
+
+        fun <T> between(attr: Attribute<T>, value1: T, value2: T) = nextAttributeName().let { attributeName ->
+            FilterExpression(
+                "#$attributeName BETWEEN :${attributeName}1 AND :${attributeName}2",
+                mapOf("#$attributeName" to attr.name),
+                mapOf(":${attributeName}1" to attr.asValue(value1), ":${attributeName}2" to attr.asValue(value2))
+            )
+        }
+
+        infix fun <T> Attribute<T>.`in`(values: Iterable<T>): FilterExpression {
+            val attributeName = nextAttributeName()
+            val attributeValues = mutableMapOf<String, AttributeValue>()
+            val expression = StringBuilder("#$attributeName IN (")
+            values.iterator().withIndex().forEach { (index, value) ->
+                val valueName = ":$attributeName$index"
+                attributeValues[valueName] = asValue(value)
+                if (index > 0) {
+                    expression.append(',')
+                }
+                expression.append(valueName)
+            }
+            expression.append(')')
+
+            require(attributeValues.isNotEmpty()) { "IN operator requires at least one element" }
+            return FilterExpression(expression.toString(), mapOf("#$attributeName" to name), attributeValues)
+        }
+
+        fun attributeExists(attr: Attribute<*>): FilterExpression = nextAttributeName().let { attributeName ->
+            FilterExpression(
+                "attribute_exists(#$attributeName)",
+                mapOf("#$attributeName" to attr.name),
+                emptyMap()
+            )
+        }
+
+        fun attributeNotExists(attr: Attribute<*>): FilterExpression = nextAttributeName().let { attributeName ->
+            FilterExpression(
+                "attribute_not_exists(#$attributeName)",
+                mapOf("#$attributeName" to attr.name),
+                emptyMap()
+            )
+        }
+
+        infix fun <T> Attribute<T>.beginsWith(value: T) = nextAttributeName().let { attributeName ->
+            FilterExpression(
+                "begins_with(#$attributeName,:$attributeName)",
+                mapOf("#$attributeName" to name),
+                mapOf(":$attributeName" to asValue(value))
+            )
+        }
+
+        infix fun <T> Attribute<T>.contains(value: T) = nextAttributeName().let { attributeName ->
+            FilterExpression(
+                "contains(#$attributeName,:$attributeName)",
+                mapOf("#$attributeName" to name),
+                mapOf(":$attributeName" to asValue(value))
+            )
+        }
+
+        infix fun FilterExpression?.and(other: FilterExpression?): FilterExpression? = when {
+            this == null -> other
+            other == null -> this
+            else -> FilterExpression(
+                "($expression AND ${other.expression})",
+                attributeNames + other.attributeNames,
+                attributeValues + other.attributeValues
+            )
+        }
+
+        infix fun FilterExpression?.or(other: FilterExpression?): FilterExpression? = when {
+            this == null -> other
+            other == null -> this
+            else -> FilterExpression(
+                "($expression OR ${other.expression})",
+                attributeNames + other.attributeNames,
+                attributeValues + other.attributeValues
+            )
+        }
+
+        fun not(expr: FilterExpression?): FilterExpression? = expr?.let {
+            FilterExpression(
+                "(NOT ${it.expression})",
+                it.attributeNames,
+                it.attributeValues
+            )
+        }
+    }
+
+    private var attributeNameCount = 0
+
+    // generate consecutive names "a", "b", ... to be used as expression attribute name
+    private fun nextAttributeName(): String {
+        val base = 'z' - 'a' + 1
+        val name = StringBuilder()
+        var currentCount = attributeNameCount
+        do {
+            val remainder = currentCount % base
+            currentCount /= base
+            name.insert(0, 'a' + remainder)
+        } while (currentCount > 0)
+
+        attributeNameCount += 1
+        return name.toString()
+    }
+
+    private var keyCondition: KeyCondition? = null
+    private var filterExpression: FilterExpression? = null
+
+    fun keyCondition(block: KeyConditionBuilder.() -> CombinedKeyCondition) {
+        keyCondition = block(KeyConditionBuilder())
+    }
+
+    fun filterExpression(block: FilterExpressionBuilder.() -> FilterExpression?) {
+        filterExpression = block(FilterExpressionBuilder())
+    }
+
+    var scanIndexForward: Boolean = true
+    var pageSize: Int? = null
+    var consistentRead: Boolean? = null
+
+    private fun <K, V> union(map1: Map<K, V>?, map2: Map<K, V>?) = when {
+        map1 == null -> map2
+        map2 == null -> map1
+        else -> map1 + map2
+    }
+
+    internal fun build() = DynamoDbQuery(
+        keyConditionExpression = keyCondition?.expression,
+        filterExpression = filterExpression?.expression,
+        expressionAttributeNames = union(keyCondition?.attributeNames, filterExpression?.attributeNames),
+        expressionAttributeValues = union(keyCondition?.attributeValues, filterExpression?.attributeValues),
+        scanIndexForward = scanIndexForward,
+        pageSize = pageSize,
+        consistentRead = consistentRead
+    )
+}
+
+fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document, HashKey, SortKey>.query(block: DynamoDbQueryBuilder.() -> Unit): Sequence<Document> {
+    val query = DynamoDbQueryBuilder().apply(block).build()
+    return query(
+        KeyConditionExpression = query.keyConditionExpression,
+        FilterExpression = query.filterExpression,
+        ExpressionAttributeNames = query.expressionAttributeNames,
+        ExpressionAttributeValues = query.expressionAttributeValues,
+        ScanIndexForward = query.scanIndexForward,
+        PageSize = query.pageSize,
+        ConsistentRead = query.consistentRead
+    )
+}
+
+fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document, HashKey, SortKey>.queryPage(
+    exclusiveStartHashKey: HashKey? = null,
+    exclusiveStartSortKey: SortKey? = null,
+    block: DynamoDbQueryBuilder.() -> Unit
+): DynamoDbPage<Document, HashKey, SortKey> {
+    val query = DynamoDbQueryBuilder().apply(block).build()
+    return queryPage(
+        KeyConditionExpression = query.keyConditionExpression,
+        FilterExpression = query.filterExpression,
+        ExpressionAttributeNames = query.expressionAttributeNames,
+        ExpressionAttributeValues = query.expressionAttributeValues,
+        ExclusiveStartHashKey = exclusiveStartHashKey,
+        ExclusiveStartSortKey = exclusiveStartSortKey,
+        ScanIndexForward = query.scanIndexForward,
+        Limit = query.pageSize,
+        ConsistentRead = query.consistentRead
+    )
+}

--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryBuilder.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryBuilder.kt
@@ -4,25 +4,24 @@ import org.http4k.connect.amazon.dynamodb.model.Attribute
 import org.http4k.connect.amazon.dynamodb.model.AttributeName
 import org.http4k.connect.amazon.dynamodb.model.AttributeValue
 
-internal class DynamoDbQuery(
+internal class DynamoDbQuery<HashKey: Any>(
     val keyConditionExpression: String?,
     val filterExpression: String?,
     val expressionAttributeNames: Map<String, AttributeName>?,
     val expressionAttributeValues: Map<String, AttributeValue>?,
-    val scanIndexForward: Boolean,
-    val pageSize: Int?,
-    val consistentRead: Boolean?
+    val exclusiveStartHashKey: HashKey?
 )
 
-interface KeyCondition {
+interface KeyCondition<HashKey: Any, SortKey: Any> {
     val expression: String
     val attributeNames: Map<String, AttributeName>
     val attributeValues: Map<String, AttributeValue>
+    val exclusiveStartHashKey: HashKey?
 }
 
-interface SortKeyCondition : KeyCondition
-interface CombinedKeyCondition : KeyCondition
-interface PartitionKeyCondition : SortKeyCondition, CombinedKeyCondition
+interface SortKeyCondition<HashKey: Any, SortKey: Any> : KeyCondition<HashKey, SortKey>
+interface CombinedKeyCondition<HashKey: Any, SortKey: Any> : KeyCondition<HashKey, SortKey>
+interface PartitionKeyCondition<HashKey: Any, SortKey: Any> : SortKeyCondition<HashKey, SortKey>, CombinedKeyCondition<HashKey, SortKey>
 
 class FilterExpression(
     val expression: String,
@@ -30,18 +29,19 @@ class FilterExpression(
     val attributeValues: Map<String, AttributeValue>
 )
 
-class DynamoDbQueryBuilder {
+class DynamoDbQueryBuilder<HashKey : Any, SortKey : Any> {
 
     /**
      * See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.KeyConditionExpressions.html
      */
     inner class KeyConditionBuilder {
 
-        infix fun <T> Attribute<T>.eq(value: T) = nextAttributeName().let { attributeName ->
-            object : PartitionKeyCondition {
+        infix fun Attribute<HashKey>.eq(value: HashKey) = nextAttributeName().let { attributeName ->
+            object : PartitionKeyCondition<HashKey, SortKey> {
                 override val expression = "#$attributeName = :$attributeName"
                 override val attributeNames = mapOf("#$attributeName" to name)
                 override val attributeValues = mapOf(":$attributeName" to asValue(value))
+                override val exclusiveStartHashKey = value
             }
         }
 
@@ -49,13 +49,14 @@ class DynamoDbQueryBuilder {
             expr: String,
             attrNames: Map<String, AttributeName>,
             attrValues: Map<String, AttributeValue>
-        ) = object : SortKeyCondition {
+        ) = object : SortKeyCondition<HashKey, SortKey> {
             override val expression = expr
             override val attributeNames = attrNames
             override val attributeValues = attrValues
+            override val exclusiveStartHashKey = null
         }
 
-        private fun <T> Attribute<T>.sortKeyOperator(op: String, value: T) = nextAttributeName().let { attributeName ->
+        private fun Attribute<SortKey>.sortKeyOperator(op: String, value: SortKey) = nextAttributeName().let { attributeName ->
             sortKeyCondition(
                 "#$attributeName $op :$attributeName",
                 mapOf("#$attributeName" to name),
@@ -63,12 +64,12 @@ class DynamoDbQueryBuilder {
             )
         }
 
-        infix fun <T> Attribute<T>.lt(value: T) = sortKeyOperator("<", value)
-        infix fun <T> Attribute<T>.le(value: T) = sortKeyOperator("<=", value)
-        infix fun <T> Attribute<T>.gt(value: T) = sortKeyOperator(">", value)
-        infix fun <T> Attribute<T>.ge(value: T) = sortKeyOperator(">=", value)
+        infix fun Attribute<SortKey>.lt(value: SortKey) = sortKeyOperator("<", value)
+        infix fun Attribute<SortKey>.le(value: SortKey) = sortKeyOperator("<=", value)
+        infix fun Attribute<SortKey>.gt(value: SortKey) = sortKeyOperator(">", value)
+        infix fun Attribute<SortKey>.ge(value: SortKey) = sortKeyOperator(">=", value)
 
-        fun <T> between(attr: Attribute<T>, value1: T, value2: T) = nextAttributeName().let { attributeName ->
+        fun between(attr: Attribute<SortKey>, value1: SortKey, value2: SortKey) = nextAttributeName().let { attributeName ->
             sortKeyCondition(
                 "#$attributeName BETWEEN :${attributeName}1 AND :${attributeName}2",
                 mapOf("#$attributeName" to attr.name),
@@ -76,7 +77,7 @@ class DynamoDbQueryBuilder {
             )
         }
 
-        infix fun <T> Attribute<T>.beginsWith(value: T) = nextAttributeName().let { attributeName ->
+        infix fun Attribute<SortKey>.beginsWith(value: SortKey) = nextAttributeName().let { attributeName ->
             sortKeyCondition(
                 "begins_with(#$attributeName,:$attributeName)",
                 mapOf("#$attributeName" to name),
@@ -84,14 +85,15 @@ class DynamoDbQueryBuilder {
             )
         }
 
-        infix fun PartitionKeyCondition.and(secondary: SortKeyCondition?): CombinedKeyCondition = let {
+        infix fun PartitionKeyCondition<HashKey, SortKey>.and(secondary: SortKeyCondition<HashKey, SortKey>?): CombinedKeyCondition<HashKey, SortKey> = let {
             if (secondary == null) {
                 this
             } else {
-                object : CombinedKeyCondition {
+                object : CombinedKeyCondition<HashKey, SortKey> {
                     override val expression = "${it.expression} AND ${secondary.expression}"
                     override val attributeNames = it.attributeNames + secondary.attributeNames
                     override val attributeValues = it.attributeValues + secondary.attributeValues
+                    override val exclusiveStartHashKey = it.exclusiveStartHashKey
                 }
             }
         }
@@ -221,20 +223,16 @@ class DynamoDbQueryBuilder {
         return name.toString()
     }
 
-    private var keyCondition: KeyCondition? = null
+    private var keyCondition: KeyCondition<HashKey, SortKey>? = null
     private var filterExpression: FilterExpression? = null
 
-    fun keyCondition(block: KeyConditionBuilder.() -> CombinedKeyCondition) {
+    fun keyCondition(block: KeyConditionBuilder.() -> CombinedKeyCondition<HashKey, SortKey>) {
         keyCondition = block(KeyConditionBuilder())
     }
 
     fun filterExpression(block: FilterExpressionBuilder.() -> FilterExpression?) {
         filterExpression = block(FilterExpressionBuilder())
     }
-
-    var scanIndexForward: Boolean = true
-    var pageSize: Int? = null
-    var consistentRead: Boolean? = null
 
     private fun <K, V> union(map1: Map<K, V>?, map2: Map<K, V>?) = when {
         map1 == null -> map2
@@ -247,40 +245,44 @@ class DynamoDbQueryBuilder {
         filterExpression = filterExpression?.expression,
         expressionAttributeNames = union(keyCondition?.attributeNames, filterExpression?.attributeNames),
         expressionAttributeValues = union(keyCondition?.attributeValues, filterExpression?.attributeValues),
-        scanIndexForward = scanIndexForward,
-        pageSize = pageSize,
-        consistentRead = consistentRead
+        exclusiveStartHashKey = keyCondition?.exclusiveStartHashKey
     )
 }
 
-fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document, HashKey, SortKey>.query(block: DynamoDbQueryBuilder.() -> Unit): Sequence<Document> {
-    val query = DynamoDbQueryBuilder().apply(block).build()
+fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document, HashKey, SortKey>.query(
+    ScanIndexForward: Boolean = true,
+    PageSize: Int? = null,
+    ConsistentRead: Boolean? = null,
+    block: DynamoDbQueryBuilder<HashKey, SortKey>.() -> Unit): Sequence<Document> {
+    val query = DynamoDbQueryBuilder<HashKey, SortKey>().apply(block).build()
     return query(
         KeyConditionExpression = query.keyConditionExpression,
         FilterExpression = query.filterExpression,
         ExpressionAttributeNames = query.expressionAttributeNames,
         ExpressionAttributeValues = query.expressionAttributeValues,
-        ScanIndexForward = query.scanIndexForward,
-        PageSize = query.pageSize,
-        ConsistentRead = query.consistentRead
+        ScanIndexForward = ScanIndexForward,
+        PageSize = PageSize,
+        ConsistentRead = ConsistentRead
     )
 }
 
 fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document, HashKey, SortKey>.queryPage(
-    exclusiveStartHashKey: HashKey? = null,
-    exclusiveStartSortKey: SortKey? = null,
-    block: DynamoDbQueryBuilder.() -> Unit
+    ScanIndexForward: Boolean = true,
+    Limit: Int? = null,
+    ConsistentRead: Boolean? = null,
+    ExclusiveStartKey: SortKey? = null,
+    block: DynamoDbQueryBuilder<HashKey, SortKey>.() -> Unit
 ): DynamoDbPage<Document, HashKey, SortKey> {
-    val query = DynamoDbQueryBuilder().apply(block).build()
+    val query = DynamoDbQueryBuilder<HashKey, SortKey>().apply(block).build()
     return queryPage(
         KeyConditionExpression = query.keyConditionExpression,
         FilterExpression = query.filterExpression,
         ExpressionAttributeNames = query.expressionAttributeNames,
         ExpressionAttributeValues = query.expressionAttributeValues,
-        ExclusiveStartHashKey = exclusiveStartHashKey,
-        ExclusiveStartSortKey = exclusiveStartSortKey,
-        ScanIndexForward = query.scanIndexForward,
-        Limit = query.pageSize,
-        ConsistentRead = query.consistentRead
+        ExclusiveStartHashKey = query.exclusiveStartHashKey,
+        ExclusiveStartSortKey = ExclusiveStartKey,
+        ScanIndexForward = ScanIndexForward,
+        Limit = Limit,
+        ConsistentRead = ConsistentRead
     )
 }

--- a/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/grammar/Contains.kt
+++ b/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/grammar/Contains.kt
@@ -14,10 +14,10 @@ object Contains : ExprFactory {
             .map { (_, attr, _, value) ->
                 Expr {
                     when (val av = attr.eval(it).asString()) {
-                        is String -> setOf(av)
-                        is Set<*> -> av
+                        is String -> av.contains(value.eval(it).asString().toString())
+                        is Set<*> -> av.contains(value.eval(it).asString())
                         else -> error("can't compare $av")
-                    }.contains(value.eval(it).asString().toString())
+                    }
                 }
             }
 }

--- a/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/grammar/DynamoDbConditionalGrammarTest.kt
+++ b/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/grammar/DynamoDbConditionalGrammarTest.kt
@@ -253,6 +253,7 @@ class DynamoDbConditionalGrammarTest {
     fun `contains function`() {
         val item = Item(attr1 of "123", attr3 of setOf("123", "456"))
         assertTrue("contains(attr1, :foo)", item, mapOf(":foo" to attr1.asValue("123")))
+        assertTrue("contains(attr1, :foo)", item, mapOf(":foo" to attr1.asValue("2")))
         assertTrue("contains(attr3, :foo)", item, mapOf(":foo" to attr1.asValue("123")))
         assertFalse("contains(attr1, :foo)", item, mapOf(":foo" to attr1.asValue("124")))
         assertFalse("contains(attr3, :foo)", item, mapOf(":foo" to attr1.asValue("124")))

--- a/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/grammar/DynamoDbConditionalGrammarTest.kt
+++ b/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/grammar/DynamoDbConditionalGrammarTest.kt
@@ -253,10 +253,11 @@ class DynamoDbConditionalGrammarTest {
     fun `contains function`() {
         val item = Item(attr1 of "123", attr3 of setOf("123", "456"))
         assertTrue("contains(attr1, :foo)", item, mapOf(":foo" to attr1.asValue("123")))
-        assertTrue("contains(attr1, :foo)", item, mapOf(":foo" to attr1.asValue("2")))
         assertTrue("contains(attr3, :foo)", item, mapOf(":foo" to attr1.asValue("123")))
         assertFalse("contains(attr1, :foo)", item, mapOf(":foo" to attr1.asValue("124")))
         assertFalse("contains(attr3, :foo)", item, mapOf(":foo" to attr1.asValue("124")))
+        assertTrue("contains(attr1, :foo)", item, mapOf(":foo" to attr1.asValue("2")))
+        assertFalse("contains(attr3, :foo)", item, mapOf(":foo" to attr1.asValue("2")))
     }
 
     @Test

--- a/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbTableMapperTest.kt
+++ b/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbTableMapperTest.kt
@@ -236,11 +236,10 @@ class DynamoDbTableMapperTest {
     @Test
     fun `custom built query page`() {
         // page 1 of 2
-        val page1 = tableMapper.index(byDob).queryPage {
+        val page1 = tableMapper.index(byDob).queryPage(Limit = 1) {
             keyCondition {
                 bornAttr eq smokie.born
             }
-            pageSize = 1
         }
         assertThat(
             page1,
@@ -249,13 +248,12 @@ class DynamoDbTableMapperTest {
 
         // page 2 of 2
         val page2 = tableMapper.index(byDob).queryPage(
-            exclusiveStartHashKey = smokie.born,
-            exclusiveStartSortKey = smokie.id
+            Limit = 1,
+            ExclusiveStartKey = smokie.id
         ) {
             keyCondition {
                 bornAttr eq smokie.born
             }
-            pageSize = 1
         }
         assertThat(
             page2,


### PR DESCRIPTION
This allows creating queries like
```
tableMapper.index(byOwner).query {
    keyCondition {
        ownerIdAttr eq owner1
    }
    filterExpression {
        val idExpr = idAttr eq kratos.id
        val bornExpr = bornAttr gt toggles.born

        not(idExpr) and bornExpr
    }
}
```

Additional changes:
- adds a queryPage function with full parameters (similar to query())
- fixes the contains(path, operand) function in FakeDynamoDB for string attribute values

Open issues:
- the size function is not supported yet
- the attribute_type function is not supported since it probably doesn't make much sense to support it (attributes are typed and can have only one type)
- comparator functions, BETWEEN, and IN don't allow attributes on their right side yet (something like `attr1 eq attr2`)

See https://github.com/http4k/http4k-connect/issues/314