### PR TITLE
FakeDynamoDb should support sparse indexes

### DIFF
--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/model/itemAndKey.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/model/itemAndKey.kt
@@ -18,4 +18,4 @@ fun Key(vararg modifiers: (Item) -> Item): Item =
 fun Item.with(vararg modifiers: (Item) -> Item): Item =
     modifiers.fold(this) { memo, next -> next(memo) }
 
-fun Item.without(vararg attributes: Attribute<*>) = minus(attributes.map { it.name })
+fun Item.without(vararg attributes: Attribute<*>): Item = minus(attributes.map { it.name })

--- a/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/helpers.kt
+++ b/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/helpers.kt
@@ -115,7 +115,18 @@ fun List<KeySchema>?.comparator(ascending: Boolean): Comparator<Item> {
 
         sortValue1.compareTo(sortValue2) * modifier
     }
+}
 
+fun List<KeySchema>?.filterNullKeys(): (Item) -> Boolean {
+    val hashKey = this?.find { it.KeyType == KeyType.HASH }
+        ?.AttributeName
+
+    val sortKey = this?.find { it.KeyType == KeyType.RANGE }
+        ?.AttributeName
+
+    return { item: Item ->
+        (hashKey == null || item[hashKey] != null) && (sortKey == null || item[sortKey] != null)
+    }
 }
 
 fun TableDescription.keySchema(indexName: IndexName? = null): List<KeySchema>? {

--- a/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/query.kt
+++ b/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/query.kt
@@ -10,10 +10,12 @@ fun AmazonJsonFake.query(tables: Storage<DynamoTable>) = route<Query> { query ->
     val table = tables[query.TableName.value] ?: return@route null
     val schema = table.table.keySchema(query.IndexName)
 
+    val filter = schema.filterNullKeys()
     val comparator = schema.comparator(query.ScanIndexForward ?: true)
 
     val matches = table.items
         .asSequence()
+        .filter(filter)
         .mapNotNull {it.condition(
             expression = query.KeyConditionExpression,
             expressionAttributeNames = query.ExpressionAttributeNames,
@@ -38,4 +40,3 @@ fun AmazonJsonFake.query(tables: Storage<DynamoTable>) = route<Query> { query ->
         } else null
     )
 }
-

--- a/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/scan.kt
+++ b/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/scan.kt
@@ -10,10 +10,12 @@ fun AmazonJsonFake.scan(tables: Storage<DynamoTable>) = route<Scan> { scan ->
     val table = tables[scan.TableName.value] ?: return@route null
     val schema = table.table.keySchema(scan.IndexName)
 
+    val filter = schema.filterNullKeys()
     val comparator = schema.comparator(true)
 
     val matches = table.items
         .asSequence()
+        .filter(filter)
         .mapNotNull {
             it.condition(
                 expression = scan.FilterExpression,

--- a/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/DynamoDbQueryContract.kt
+++ b/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/DynamoDbQueryContract.kt
@@ -27,6 +27,7 @@ import org.http4k.connect.amazon.dynamodb.model.ReqWriteItem
 import org.http4k.connect.amazon.dynamodb.model.TableName
 import org.http4k.connect.amazon.dynamodb.model.asAttributeDefinition
 import org.http4k.connect.amazon.dynamodb.model.compound
+import org.http4k.connect.amazon.dynamodb.model.without
 import org.http4k.connect.amazon.dynamodb.putItem
 import org.http4k.connect.amazon.dynamodb.query
 import org.http4k.connect.amazon.dynamodb.sample
@@ -44,6 +45,7 @@ abstract class DynamoDbQueryContract: DynamoDbSource {
         private val hash1Val1 = createItem("hash1", 1, Base64Blob.encode("spam"))
         private val hash1Val2 = createItem("hash1", 2, Base64Blob.encode("ham"))
         private val hash2Val1 = createItem("hash2", 1, Base64Blob.encode("eggs"))
+        private val hash1Val3WithoutBinary = createItem("hash1", 3).without(attrB)
 
         private val numbersIndex = IndexName.of("numbers")
         private val stringAndBinaryIndex = IndexName.of("string-bin")
@@ -196,6 +198,7 @@ abstract class DynamoDbQueryContract: DynamoDbSource {
         dynamo.putItem(table, hash1Val1)
         dynamo.putItem(table, hash1Val2)
         dynamo.putItem(table, hash2Val1)
+        dynamo.putItem(table, hash1Val3WithoutBinary)
 
         val result = dynamo.query(
             TableName = table,


### PR DESCRIPTION
Scan and query operations will no longer return items that don't have the hash or sort key attributes set.

Fixes https://github.com/http4k/http4k-connect/issues/322