### PR TITLE
Fix contains() function in FakeDynamoDb

### DIFF
--- a/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/grammar/Contains.kt
+++ b/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/grammar/Contains.kt
@@ -14,10 +14,10 @@ object Contains : ExprFactory {
             .map { (_, attr, _, value) ->
                 Expr {
                     when (val av = attr.eval(it).asString()) {
-                        is String -> setOf(av)
-                        is Set<*> -> av
+                        is String -> av.contains(value.eval(it).asString().toString())
+                        is Set<*> -> av.contains(value.eval(it).asString())
                         else -> error("can't compare $av")
-                    }.contains(value.eval(it).asString().toString())
+                    }
                 }
             }
 }

--- a/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/grammar/DynamoDbConditionalGrammarTest.kt
+++ b/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/grammar/DynamoDbConditionalGrammarTest.kt
@@ -256,6 +256,8 @@ class DynamoDbConditionalGrammarTest {
         assertTrue("contains(attr3, :foo)", item, mapOf(":foo" to attr1.asValue("123")))
         assertFalse("contains(attr1, :foo)", item, mapOf(":foo" to attr1.asValue("124")))
         assertFalse("contains(attr3, :foo)", item, mapOf(":foo" to attr1.asValue("124")))
+        assertTrue("contains(attr1, :foo)", item, mapOf(":foo" to attr1.asValue("2")))
+        assertFalse("contains(attr3, :foo)", item, mapOf(":foo" to attr1.asValue("2")))
     }
 
     @Test


### PR DESCRIPTION
For strings the contains() function evaluates to true if the operand is a substring of the DB value. See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html