### PR TITLE
Allow null Attributes to be ignored in the request to DynamoDb

### DIFF
--- a/amazon/dynamodb/client/src/test/kotlin/org/http4k/connect/amazon/dynamodb/model/AttributeTest.kt
+++ b/amazon/dynamodb/client/src/test/kotlin/org/http4k/connect/amazon/dynamodb/model/AttributeTest.kt
@@ -12,6 +12,7 @@ import dev.forkhandles.values.StringValue
 import dev.forkhandles.values.StringValueFactory
 import dev.forkhandles.values.UUIDValue
 import dev.forkhandles.values.UUIDValueFactory
+import org.http4k.connect.amazon.dynamodb.model.AttributeValue.Companion.Null
 import org.http4k.connect.amazon.dynamodb.model.AttributeValue.Companion.Num
 import org.http4k.connect.amazon.dynamodb.model.AttributeValue.Companion.Str
 import org.http4k.lens.LensFailure
@@ -52,6 +53,27 @@ class AttributeTest {
             primary(Item(fallback of UUID(0, 0))),
             equalTo(UUID(0,0))
         )
+    }
+
+    @Test
+    fun `may ignore null values in optional attributes`() {
+        // given
+        val optionalWithNull = Attribute.string().optional("withNull")
+        val optionalWithoutNull = Attribute.string().optional("withoutNull", ignoreNull = true)
+
+        // when
+        val itemWithNull = Item(optionalWithNull of null)
+        val itemWithoutNull = Item(optionalWithoutNull of null)
+        val itemWithValue = Item(optionalWithoutNull of "something")
+
+        // then
+        assertThat(itemWithNull, equalTo(mapOf(optionalWithNull.name to Null())))
+        assertThat(itemWithoutNull, equalTo(emptyMap()))
+        assertThat(itemWithValue, equalTo(mapOf(optionalWithoutNull.name to Str("something"))))
+
+        assertThat(optionalWithNull(itemWithNull), equalTo(null))
+        assertThat(optionalWithoutNull(itemWithoutNull), equalTo(null))
+        assertThat(optionalWithoutNull(itemWithValue), equalTo("something"))
     }
 
     @Test


### PR DESCRIPTION
Adds a parameter `ignoreNull` to the `AttrLensSpec.optional()` factory function. Optional attributes with value `null` and `ignoreNull = true` will be missing when sent to DynamoDb. This enables using secondary indexes on optional attributes (aka sparse indexes), since an explicit null value (`{ "NULL": true }`) is not an allowed value for an index key attribute.

See also https://github.com/http4k/http4k-connect/issues/321