### PR TITLE
Throw exception if delete fails in DynamoDbTableMapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This list is not intended to be all-encompassing - it will document major and breaking API 
 changes with their rationale when appropriate. Given version `A.B.C.D`, breaking changes are to be expected in version number increments where changes in the `A` or `B` sections:
 
+### v5.6.6.0 (uncut)
+- **http4k-connect-amazon-dynamodb-client*** - [Fix] #344 Handle failures in `DynamoDbTableMapper.delete()` H/T @obecker
+
 ### v5.6.5.0
 - **http4k-connect-*** - Upgrade dependencies.
 - **http4k-connect-*** - Fix `AutomarshalledPagedAction` so that it deals with pages of results which do not get returned inside a list but in an object wrapping a list.

--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbTableMapper.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbTableMapper.kt
@@ -96,7 +96,7 @@ class DynamoDbTableMapper<Document : Any, HashKey : Any, SortKey : Any>(
         dynamoDb.deleteItem(
             TableName = tableName,
             Key = primarySchema.key(hashKey, sortKey)
-        )
+        ).onFailure { it.reason.throwIt() }
     }
 
     fun delete(document: Document) {


### PR DESCRIPTION
The `delete` function in `DynamoDbTableMapper` no longer silently ignores failures returned from DynamoDB.
It now throws the failure the same way all other functions in `DynamoDbTableMapper` are doing it.