### PR TITLE
Support converting dynamo set to java set

### DIFF
--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/format/autoMarshalingExtensions.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/format/autoMarshalingExtensions.kt
@@ -31,6 +31,8 @@ fun fromAttributeValue(value: AttributeValue): Any? = value.N
     ?: value.S
     ?: value.M?.map { it.key.value to fromAttributeValue(it.value) }?.toMap()
     ?: value.L?.map(::fromAttributeValue)?.toTypedArray()
+    ?: value.SS?.toTypedArray()
+    ?: value.NS?.toTypedArray()
 
 @Suppress("UNCHECKED_CAST")
 private fun toAttributeValue(value: Any?): AttributeValue = when (value) {

--- a/amazon/dynamodb/client/src/test/kotlin/org/http4k/format/AutoMarshalingExtensionsTest.kt
+++ b/amazon/dynamodb/client/src/test/kotlin/org/http4k/format/AutoMarshalingExtensionsTest.kt
@@ -89,4 +89,21 @@ class AutoMarshalingExtensionsTest {
             equalTo(expectedItem)
         )
     }
+
+    data class DynamoSetContainer(val names: Set<String>, val ids: Set<Int>)
+
+    @Test
+    fun `can convert Item with SS and NS into object`() {
+        val item = mapOf(
+            AttributeName.of("names") to AttributeValue.StrSet(setOf("Kratos", "Athena")),
+            AttributeName.of("ids") to AttributeValue.NumSet(setOf(1, 2))
+        )
+
+        val lens = DynamoDbMoshi.autoDynamoLens<DynamoSetContainer>()
+
+        assertThat(
+            lens(item),
+            equalTo(DynamoSetContainer(names = setOf("Kratos", "Athena"), ids = setOf(1, 2)))
+        )
+    }
 }


### PR DESCRIPTION
I don't think it's possible to support converting java set to dynamo set with the current JSON-backed strategy.  Making a new issue to discuss it.