### PR TITLE
Add count() convenience function to DynamoDbIndexMapper

### DIFF
--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/action/Query.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/action/Query.kt
@@ -40,9 +40,9 @@ data class Query(
 data class QueryResponse(
     internal val Items: List<ItemResult>? = null,
     val ConsumedCapacity: ConsumedCapacity? = null,
-    val Count: Int? = null,
+    val Count: Int = 0,
     val LastEvaluatedKey: Key? = null,
-    val ScannedCount: Int? = null
+    val ScannedCount: Int = 0
 ) : Paged<Key, Item> {
     override val items = Items?.map(ItemResult::toItem) ?: emptyList()
     override fun token() = LastEvaluatedKey

--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/action/Scan.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/action/Scan.kt
@@ -8,6 +8,7 @@ import org.http4k.connect.amazon.dynamodb.model.Item
 import org.http4k.connect.amazon.dynamodb.model.ItemResult
 import org.http4k.connect.amazon.dynamodb.model.Key
 import org.http4k.connect.amazon.dynamodb.model.ReturnConsumedCapacity
+import org.http4k.connect.amazon.dynamodb.model.Select
 import org.http4k.connect.amazon.dynamodb.model.TableName
 import org.http4k.connect.amazon.dynamodb.model.TokensToNames
 import org.http4k.connect.amazon.dynamodb.model.TokensToValues
@@ -28,7 +29,7 @@ data class Scan(
     override val Limit: Int? = null,
     val ConsistentRead: Boolean? = null,
     val Segment: Int? = null,
-    val Select: String? = null,
+    val Select: Select? = null,
     val TotalSegments: Int? = null,
     val ReturnConsumedCapacity: ReturnConsumedCapacity? = null,
 ) : DynamoDbPagedAction<ScanResponse, Scan>(kClass()) {
@@ -38,9 +39,9 @@ data class Scan(
 @JsonSerializable
 data class ScanResponse(
     val ConsumedCapacity: ConsumedCapacity? = null,
-    val Count: Int? = null,
+    val Count: Int = 0,
     val LastEvaluatedKey: Key? = null,
-    val ScannedCount: Int? = null,
+    val ScannedCount: Int = 0,
     internal val Items: List<ItemResult>? = null
 ) : Paged<Key, Item> {
     override val items = Items?.map(ItemResult::toItem) ?: emptyList()

--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryDsl.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryDsl.kt
@@ -379,3 +379,17 @@ fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document,
         ConsistentRead = ConsistentRead
     )
 }
+
+fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document, HashKey, SortKey>.count(
+    ConsistentRead: Boolean? = null,
+    block: DynamoDbQueryBuilder<HashKey, SortKey>.() -> Unit
+): Int {
+    val query = DynamoDbQueryBuilder<HashKey, SortKey>().apply(block).build()
+    return count(
+        KeyConditionExpression = query.keyConditionExpression,
+        FilterExpression = query.filterExpression,
+        ExpressionAttributeNames = query.expressionAttributeNames,
+        ExpressionAttributeValues = query.expressionAttributeValues,
+        ConsistentRead = ConsistentRead
+    )
+}

--- a/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbTableMapperTest.kt
+++ b/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbTableMapperTest.kt
@@ -355,4 +355,30 @@ class DynamoDbTableMapperTest {
         val batchGetResult = tableMapper[cats.map { it.id }].toList()
         assertThat(batchGetResult, equalTo(cats))
     }
+
+    @Test
+    fun `count (via scan)`() {
+        val totalCount = tableMapper.primaryIndex().count()
+        assertThat(totalCount, equalTo(5))
+    }
+
+    @Test
+    fun `count (via scan with filter)`() {
+        val totalCount = tableMapper.primaryIndex().count {
+            filterExpression {
+                bornAttr gt LocalDate.of(2010, 1, 1)
+            }
+        }
+        assertThat(totalCount, equalTo(4))
+    }
+
+    @Test
+    fun `count (via query)`() {
+        val totalCount = tableMapper.primaryIndex().count {
+            keyCondition {
+                ownerIdAttr eq owner1
+            }
+        }
+        assertThat(totalCount, equalTo(3))
+    }
 }


### PR DESCRIPTION
Returns the number of items matching the given key condition and/or filter expression.

API changes:
- Scan.Select is now a Select enum (previously String)
- ScanResponse and QueryResponse have now non-optional Count and ScannedCount members (as stated in the AWS API documentation)