### PR TITLE
openai: extra constants + json-mode

### DIFF
--- a/openai/client/src/main/kotlin/org/http4k/connect/openai/OpenAIMoshi.kt
+++ b/openai/client/src/main/kotlin/org/http4k/connect/openai/OpenAIMoshi.kt
@@ -28,6 +28,7 @@ object OpenAIMoshi : ConfigurableMoshi(
         .value(Timestamp)
         .value(TokenId)
         .value(User)
+        .value(ResponseFormatType)
         .done()
 )
 

--- a/openai/client/src/main/kotlin/org/http4k/connect/openai/action/ChatCompletion.kt
+++ b/openai/client/src/main/kotlin/org/http4k/connect/openai/action/ChatCompletion.kt
@@ -45,7 +45,7 @@ data class ChatCompletion(
     val logit_bias: Map<TokenId, Double>? = null,
     val user: User? = null,
     val stream: Boolean = false,
-    val responseFormat: ResponseFormat? = null
+    val response_format: ResponseFormat? = null
 ) : OpenAIAction<Sequence<CompletionResponse>> {
     constructor(model: ModelName, messages: List<Message>, max_tokens: Int = 16, stream: Boolean = true) : this(
         model,

--- a/openai/client/src/main/kotlin/org/http4k/connect/openai/action/ChatCompletion.kt
+++ b/openai/client/src/main/kotlin/org/http4k/connect/openai/action/ChatCompletion.kt
@@ -12,6 +12,7 @@ import org.http4k.connect.openai.ObjectType
 import org.http4k.connect.openai.OpenAIAction
 import org.http4k.connect.openai.OpenAIMoshi
 import org.http4k.connect.openai.OpenAIMoshi.autoBody
+import org.http4k.connect.openai.ResponseFormatType
 import org.http4k.connect.openai.Role
 import org.http4k.connect.openai.Timestamp
 import org.http4k.connect.openai.TokenId
@@ -43,7 +44,8 @@ data class ChatCompletion(
     val frequency_penalty: Double = 0.0,
     val logit_bias: Map<TokenId, Double>? = null,
     val user: User? = null,
-    val stream: Boolean = false
+    val stream: Boolean = false,
+    val responseFormat: ResponseFormat? = null
 ) : OpenAIAction<Sequence<CompletionResponse>> {
     constructor(model: ModelName, messages: List<Message>, max_tokens: Int = 16, stream: Boolean = true) : this(
         model,
@@ -91,6 +93,11 @@ data class ChatCompletion(
         }
     }
 }
+
+@JsonSerializable
+data class ResponseFormat(
+    val type: ResponseFormatType
+)
 
 @JsonSerializable
 data class Message(

--- a/openai/client/src/main/kotlin/org/http4k/connect/openai/model.kt
+++ b/openai/client/src/main/kotlin/org/http4k/connect/openai/model.kt
@@ -51,6 +51,12 @@ class ModelName private constructor(value: String) : StringValue(value) {
     }
 }
 
+class ResponseFormatType private constructor(value: String) : StringValue(value) {
+    companion object : NonBlankStringValueFactory<ResponseFormatType>(::ResponseFormatType) {
+        val JsonObject = ResponseFormatType.of("json_object")
+    }
+}
+
 class Role private constructor(value: String) : StringValue(value) {
     companion object : NonBlankStringValueFactory<Role>(::Role) {
         val System = Role.of("system")

--- a/openai/client/src/main/kotlin/org/http4k/connect/openai/model.kt
+++ b/openai/client/src/main/kotlin/org/http4k/connect/openai/model.kt
@@ -45,6 +45,7 @@ class Timestamp private constructor(value: Long) : LongValue(value) {
 class ModelName private constructor(value: String) : StringValue(value) {
     companion object : NonBlankStringValueFactory<ModelName>(::ModelName) {
         val GPT4 = ModelName.of("gpt-4")
+        val GPT4_TURBO_PREVIEW = ModelName.of("gpt-4-turbo-preview")
         val GPT3_5 = ModelName.of("gpt-3.5-turbo")
         val TEXT_EMBEDDING_ADA_002 = ModelName.of("text-embedding-ada-002")
     }
@@ -54,6 +55,7 @@ class Role private constructor(value: String) : StringValue(value) {
     companion object : NonBlankStringValueFactory<Role>(::Role) {
         val System = Role.of("system")
         val User = Role.of("user")
+        val Assistant = Role.of("assistant")
     }
 }
 


### PR DESCRIPTION
- added a constant for `gpt-4-turbo-preview`
- added a constant for the `assistant` role
- added support for [json-mode](https://platform.openai.com/docs/guides/text-generation/json-mode)