### PR TITLE
FakeDynamoDb.query to return proper lastEvaluatedKey for indices

### DIFF
--- a/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/query.kt
+++ b/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/query.kt
@@ -42,8 +42,15 @@ fun AmazonJsonFake.query(tables: Storage<DynamoTable>) = route<Query> { query ->
     QueryResponse(
         Count = filteredPage.size,
         Items = filteredPage.map { it.asItemResult() },
-        LastEvaluatedKey = if (page.size < matches.size && schema != null) {
-            page.lastOrNull()?.key(schema)
-        } else null
+        LastEvaluatedKey = page.lastOrNull()
+            ?.takeIf { page.size < matches.size }
+            ?.let { last ->
+                buildMap {
+                    this += last.key(table.table.KeySchema!!)
+                    if (schema != null) {
+                        this += last.key(schema)
+                    }
+                }
+            }
     )
 }


### PR DESCRIPTION
When performing `query` or `scan` on an index, the union of the primary and index key is to be returned as the `lastEvaluatedKey`.  Previously, `query` would only return the index key.