### PR TITLE
Review DynamoDB query DSL: introduce special values hashKey and sortKey

### DIFF
--- a/amazon/dynamodb/README.md
+++ b/amazon/dynamodb/README.md
@@ -177,7 +177,7 @@ val people = table.primaryIndex().scan {
 // query with key condition (doesn't actually make much sense is this example)
 val anotherJohn = table.primaryIndex().query {
     keyCondition {
-        idAttr eq john.id
+        hashKey eq john.id
     }
 }
 ```
@@ -186,7 +186,7 @@ General query pattern with combined key condition and filter expression
 ```kotlin
 table.primaryIndex().query {
     keyCondition {
-        (hashKeyAttr eq hashValue) and (sortKeyAttr gt sortValue)
+        (hashKey eq hashValue) and (sortKey gt sortValue)
     }
     filterExpression {
         (fooAttr ne "foo") or (barAttr isIn listOf(5, 6, 7)) and (bazAttr lt quzAttr)
@@ -195,12 +195,16 @@ table.primaryIndex().query {
 ```
 
 Notes:
+ - `hashKey` and `sortKey` are special identifiers to be used in the `keyCondition` that represent the actual key 
+   attributes of the current index
  - the hash key condition must use the `eq` operator (no other operators allowed),  
  - in the sort key condition the following operators are supported: `eq` `gt`,`ge`,`lt`, `le` (for `=`, `>`, `>=`, `<`, `<=`), 
-   `beginsWith`, and the `between(sortKeyAttr, val1, val2)` function
- - the filter expression supports all of the above plus `ne` (`<>`), `isIn`, `contains`, `attributeExists(attr)`, and `attributeNotExists(attr)`
- - in a filter expression the first operand in a comparison must be an attribute, the second operand is either a value or another attribute of the same type
-   (so `xAttr eq 42` and `xAttr ne yAttr` are supported, but `42 eq xAttr` is not) 
+   `beginsWith`, and the `sortKey.between(val1, val2)` function
+ - in the filter expression concrete attributes must be used instead of `hashKey` or `sortKey`
+ - the filter expression supports all of the above operators plus `ne` (`<>`), `isIn`, `contains`, `attributeExists(attr)`,
+   and `attributeNotExists(attr)`
+ - in a filter expression the first operand in a comparison must be an attribute, the second operand is either a value
+   or another attribute of the same type (so `xAttr eq 42` and `xAttr ne yAttr` are supported, but `42 eq xAttr` is not) 
  - the logical operators `and` and `or` in this DSL are always evaluated from left to right (i.e. there is no higher precedence for `and`),
    you should use parenthesis to change the order of evaluation 
  - if an operand of a logical operator is `null` it will simply be omitted. This allows building queries with optional conditions:

--- a/amazon/dynamodb/client/src/examples/kotlin/using_the_table_mapper.kt
+++ b/amazon/dynamodb/client/src/examples/kotlin/using_the_table_mapper.kt
@@ -2,8 +2,11 @@ import org.http4k.connect.amazon.dynamodb.DynamoDb
 import org.http4k.connect.amazon.dynamodb.Http
 import org.http4k.connect.amazon.dynamodb.mapper.DynamoDbTableMapperSchema
 import org.http4k.connect.amazon.dynamodb.mapper.batchDelete
+import org.http4k.connect.amazon.dynamodb.mapper.count
 import org.http4k.connect.amazon.dynamodb.mapper.get
 import org.http4k.connect.amazon.dynamodb.mapper.plusAssign
+import org.http4k.connect.amazon.dynamodb.mapper.query
+import org.http4k.connect.amazon.dynamodb.mapper.scan
 import org.http4k.connect.amazon.dynamodb.mapper.tableMapper
 import org.http4k.connect.amazon.dynamodb.model.Attribute
 import org.http4k.connect.amazon.dynamodb.model.IndexName
@@ -20,6 +23,7 @@ private data class KittyCat(
 // define our key attributes (for primary and secondary indexes)
 private val idAttr = Attribute.uuid().required("id")
 private val ownerIdAttr = Attribute.uuid().required("ownerId")
+private val nameAttr = Attribute.string().required("name")
 
 // define the primary index
 private val primaryIndex = DynamoDbTableMapperSchema.Primary(idAttr)
@@ -50,10 +54,12 @@ fun main() {
     val tigger = KittyCat(owner1, "Tigger")
     val smokie = KittyCat(owner2, "Smokie")
     val bandit = KittyCat(owner2, "Bandit")
+    val bailey = KittyCat(owner1, "Bailey")
+    val shadow = KittyCat(owner2, "Shadow")
 
     // add the documents to the table
     table += tigger  // ...individually
-    table += listOf(smokie, bandit) // ...batched
+    table += listOf(smokie, bandit, bailey, shadow) // ...batched
 
     // get documents
     val cat = table[tigger.id] // individually
@@ -62,8 +68,24 @@ fun main() {
     // query documents
     val ownerCats = table.index(ownerIndex).query(owner2).take(100)
 
+    // scan all cats with filter by name
+    val bCats = table.primaryIndex().scan {
+        filterExpression { nameAttr beginsWith "B" }
+    }
+
+    // query cats by owner (key) and name (non-key)
+    val aoCats = table.index(ownerIndex).query {
+        keyCondition { hashKey eq owner2 }
+        filterExpression { (nameAttr contains "a") and (nameAttr contains "o") }
+    }
+
+    // count owner1's cats
+    val number = table.index(ownerIndex).count {
+        keyCondition { hashKey eq owner1 }
+    }
+
     // delete documents
     table.delete(tigger) // ...individually
     table.delete(smokie.id)  // ...by key
-    table.batchDelete(smokie.id, bandit.id) // ...batched
+    table.batchDelete(bandit.id, bailey.id, shadow.id) // ...batched
 }

--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbIndexMapper.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbIndexMapper.kt
@@ -18,7 +18,7 @@ class DynamoDbIndexMapper<Document : Any, HashKey : Any, SortKey : Any>(
     private val dynamoDb: DynamoDb,
     private val tableName: TableName,
     private val itemLens: BiDiLens<Item, Document>,
-    private val schema: DynamoDbTableMapperSchema<HashKey, SortKey>
+    internal val schema: DynamoDbTableMapperSchema<HashKey, SortKey>
 ) {
     fun scan(
         FilterExpression: String? = null,
@@ -37,21 +37,6 @@ class DynamoDbIndexMapper<Document : Any, HashKey : Any, SortKey : Any>(
         )
         .flatMap { result -> result.onFailure { it.reason.throwIt() } }
         .map(itemLens)
-
-    fun scan(
-        PageSize: Int? = null,
-        ConsistentRead: Boolean? = null,
-        block: DynamoDbScanBuilder.() -> Unit
-    ): Sequence<Document> {
-        val scan = DynamoDbScanBuilder().apply(block).build()
-        return scan(
-            FilterExpression = scan.filterExpression,
-            ExpressionAttributeNames = scan.expressionAttributeNames,
-            ExpressionAttributeValues = scan.expressionAttributeValues,
-            PageSize = PageSize,
-            ConsistentRead = ConsistentRead
-        )
-    }
 
     fun scanPage(
         FilterExpression: String? = null,
@@ -75,23 +60,6 @@ class DynamoDbIndexMapper<Document : Any, HashKey : Any, SortKey : Any>(
         return DynamoDbPage(
             items = page.items.map(itemLens),
             lastEvaluatedKey = page.LastEvaluatedKey
-        )
-    }
-
-    fun scanPage(
-        ExclusiveStartKey: Key? = null,
-        Limit: Int? = null,
-        ConsistentRead: Boolean? = null,
-        block: DynamoDbScanBuilder.() -> Unit
-    ): DynamoDbPage<Document> {
-        val scan = DynamoDbScanBuilder().apply(block).build()
-        return scanPage(
-            FilterExpression = scan.filterExpression,
-            ExpressionAttributeNames = scan.expressionAttributeNames,
-            ExpressionAttributeValues = scan.expressionAttributeValues,
-            ExclusiveStartKey = ExclusiveStartKey,
-            Limit = Limit,
-            ConsistentRead = ConsistentRead
         )
     }
 
@@ -131,24 +99,6 @@ class DynamoDbIndexMapper<Document : Any, HashKey : Any, SortKey : Any>(
         PageSize = PageSize,
         ConsistentRead = ConsistentRead
     )
-
-    fun query(
-        ScanIndexForward: Boolean = true,
-        PageSize: Int? = null,
-        ConsistentRead: Boolean? = null,
-        block: DynamoDbQueryBuilder<HashKey, SortKey>.() -> Unit
-    ): Sequence<Document> {
-        val query = DynamoDbQueryBuilder(schema).apply(block).build()
-        return query(
-            KeyConditionExpression = query.keyConditionExpression,
-            FilterExpression = query.filterExpression,
-            ExpressionAttributeNames = query.expressionAttributeNames,
-            ExpressionAttributeValues = query.expressionAttributeValues,
-            ScanIndexForward = ScanIndexForward,
-            PageSize = PageSize,
-            ConsistentRead = ConsistentRead
-        )
-    }
 
     fun queryPage(
         KeyConditionExpression: String? = null,
@@ -195,26 +145,6 @@ class DynamoDbIndexMapper<Document : Any, HashKey : Any, SortKey : Any>(
         ConsistentRead = ConsistentRead
     )
 
-    fun queryPage(
-        ScanIndexForward: Boolean = true,
-        Limit: Int? = null,
-        ConsistentRead: Boolean? = null,
-        ExclusiveStartKey: Key? = null,
-        block: DynamoDbQueryBuilder<HashKey, SortKey>.() -> Unit
-    ): DynamoDbPage<Document> {
-        val query = DynamoDbQueryBuilder(schema).apply(block).build()
-        return queryPage(
-            KeyConditionExpression = query.keyConditionExpression,
-            FilterExpression = query.filterExpression,
-            ExpressionAttributeNames = query.expressionAttributeNames,
-            ExpressionAttributeValues = query.expressionAttributeValues,
-            ExclusiveStartKey = ExclusiveStartKey,
-            ScanIndexForward = ScanIndexForward,
-            Limit = Limit,
-            ConsistentRead = ConsistentRead
-        )
-    }
-
     fun count(
         KeyConditionExpression: String? = null,
         FilterExpression: String? = null,
@@ -257,19 +187,5 @@ class DynamoDbIndexMapper<Document : Any, HashKey : Any, SortKey : Any>(
             } while (startKey != null)
         }
         return count
-    }
-
-    fun count(
-        ConsistentRead: Boolean? = null,
-        block: DynamoDbQueryBuilder<HashKey, SortKey>.() -> Unit
-    ): Int {
-        val query = DynamoDbQueryBuilder(schema).apply(block).build()
-        return count(
-            KeyConditionExpression = query.keyConditionExpression,
-            FilterExpression = query.filterExpression,
-            ExpressionAttributeNames = query.expressionAttributeNames,
-            ExpressionAttributeValues = query.expressionAttributeValues,
-            ConsistentRead = ConsistentRead
-        )
     }
 }

--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbIndexMapper.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbIndexMapper.kt
@@ -20,6 +20,9 @@ class DynamoDbIndexMapper<Document : Any, HashKey : Any, SortKey : Any>(
     private val itemLens: BiDiLens<Item, Document>,
     private val schema: DynamoDbTableMapperSchema<HashKey, SortKey>
 ) {
+    internal val hashKeyAttribute get() = schema.hashKeyAttribute
+    internal val sortKeyAttribute get() = schema.sortKeyAttribute
+
     fun scan(
         FilterExpression: String? = null,
         ExpressionAttributeNames: TokensToNames? = null,

--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbIndexMapper.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbIndexMapper.kt
@@ -18,7 +18,7 @@ class DynamoDbIndexMapper<Document : Any, HashKey : Any, SortKey : Any>(
     private val dynamoDb: DynamoDb,
     private val tableName: TableName,
     private val itemLens: BiDiLens<Item, Document>,
-    internal val schema: DynamoDbTableMapperSchema<HashKey, SortKey>
+    private val schema: DynamoDbTableMapperSchema<HashKey, SortKey>
 ) {
     fun scan(
         FilterExpression: String? = null,
@@ -37,6 +37,21 @@ class DynamoDbIndexMapper<Document : Any, HashKey : Any, SortKey : Any>(
         )
         .flatMap { result -> result.onFailure { it.reason.throwIt() } }
         .map(itemLens)
+
+    fun scan(
+        PageSize: Int? = null,
+        ConsistentRead: Boolean? = null,
+        block: DynamoDbScanBuilder.() -> Unit
+    ): Sequence<Document> {
+        val scan = DynamoDbScanBuilder().apply(block).build()
+        return scan(
+            FilterExpression = scan.filterExpression,
+            ExpressionAttributeNames = scan.expressionAttributeNames,
+            ExpressionAttributeValues = scan.expressionAttributeValues,
+            PageSize = PageSize,
+            ConsistentRead = ConsistentRead
+        )
+    }
 
     fun scanPage(
         FilterExpression: String? = null,
@@ -60,6 +75,23 @@ class DynamoDbIndexMapper<Document : Any, HashKey : Any, SortKey : Any>(
         return DynamoDbPage(
             items = page.items.map(itemLens),
             lastEvaluatedKey = page.LastEvaluatedKey
+        )
+    }
+
+    fun scanPage(
+        ExclusiveStartKey: Key? = null,
+        Limit: Int? = null,
+        ConsistentRead: Boolean? = null,
+        block: DynamoDbScanBuilder.() -> Unit
+    ): DynamoDbPage<Document> {
+        val scan = DynamoDbScanBuilder().apply(block).build()
+        return scanPage(
+            FilterExpression = scan.filterExpression,
+            ExpressionAttributeNames = scan.expressionAttributeNames,
+            ExpressionAttributeValues = scan.expressionAttributeValues,
+            ExclusiveStartKey = ExclusiveStartKey,
+            Limit = Limit,
+            ConsistentRead = ConsistentRead
         )
     }
 
@@ -99,6 +131,24 @@ class DynamoDbIndexMapper<Document : Any, HashKey : Any, SortKey : Any>(
         PageSize = PageSize,
         ConsistentRead = ConsistentRead
     )
+
+    fun query(
+        ScanIndexForward: Boolean = true,
+        PageSize: Int? = null,
+        ConsistentRead: Boolean? = null,
+        block: DynamoDbQueryBuilder<HashKey, SortKey>.() -> Unit
+    ): Sequence<Document> {
+        val query = DynamoDbQueryBuilder(schema).apply(block).build()
+        return query(
+            KeyConditionExpression = query.keyConditionExpression,
+            FilterExpression = query.filterExpression,
+            ExpressionAttributeNames = query.expressionAttributeNames,
+            ExpressionAttributeValues = query.expressionAttributeValues,
+            ScanIndexForward = ScanIndexForward,
+            PageSize = PageSize,
+            ConsistentRead = ConsistentRead
+        )
+    }
 
     fun queryPage(
         KeyConditionExpression: String? = null,
@@ -145,6 +195,26 @@ class DynamoDbIndexMapper<Document : Any, HashKey : Any, SortKey : Any>(
         ConsistentRead = ConsistentRead
     )
 
+    fun queryPage(
+        ScanIndexForward: Boolean = true,
+        Limit: Int? = null,
+        ConsistentRead: Boolean? = null,
+        ExclusiveStartKey: Key? = null,
+        block: DynamoDbQueryBuilder<HashKey, SortKey>.() -> Unit
+    ): DynamoDbPage<Document> {
+        val query = DynamoDbQueryBuilder(schema).apply(block).build()
+        return queryPage(
+            KeyConditionExpression = query.keyConditionExpression,
+            FilterExpression = query.filterExpression,
+            ExpressionAttributeNames = query.expressionAttributeNames,
+            ExpressionAttributeValues = query.expressionAttributeValues,
+            ExclusiveStartKey = ExclusiveStartKey,
+            ScanIndexForward = ScanIndexForward,
+            Limit = Limit,
+            ConsistentRead = ConsistentRead
+        )
+    }
+
     fun count(
         KeyConditionExpression: String? = null,
         FilterExpression: String? = null,
@@ -187,5 +257,19 @@ class DynamoDbIndexMapper<Document : Any, HashKey : Any, SortKey : Any>(
             } while (startKey != null)
         }
         return count
+    }
+
+    fun count(
+        ConsistentRead: Boolean? = null,
+        block: DynamoDbQueryBuilder<HashKey, SortKey>.() -> Unit
+    ): Int {
+        val query = DynamoDbQueryBuilder(schema).apply(block).build()
+        return count(
+            KeyConditionExpression = query.keyConditionExpression,
+            FilterExpression = query.filterExpression,
+            ExpressionAttributeNames = query.expressionAttributeNames,
+            ExpressionAttributeValues = query.expressionAttributeValues,
+            ConsistentRead = ConsistentRead
+        )
     }
 }

--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbIndexMapper.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbIndexMapper.kt
@@ -18,11 +18,8 @@ class DynamoDbIndexMapper<Document : Any, HashKey : Any, SortKey : Any>(
     private val dynamoDb: DynamoDb,
     private val tableName: TableName,
     private val itemLens: BiDiLens<Item, Document>,
-    private val schema: DynamoDbTableMapperSchema<HashKey, SortKey>
+    internal val schema: DynamoDbTableMapperSchema<HashKey, SortKey>
 ) {
-    internal val hashKeyAttribute get() = schema.hashKeyAttribute
-    internal val sortKeyAttribute get() = schema.sortKeyAttribute
-
     fun scan(
         FilterExpression: String? = null,
         ExpressionAttributeNames: TokensToNames? = null,

--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryDsl.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryDsl.kt
@@ -40,16 +40,16 @@ class DynamoDbScanAndQueryBuilder<HashKey : Any, SortKey : Any>(
     private val hashKeyAttribute: Attribute<HashKey>,
     private val sortKeyAttribute: Attribute<SortKey>?
 ) {
-    object HashKeyDelegate
-    object SortKeyDelegate
+    object HashKeySubstitute
+    object SortKeySubstitute
 
     /**
      * See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.KeyConditionExpressions.html
      */
     inner class KeyConditionBuilder {
 
-        val hashKey = HashKeyDelegate
-        val sortKey = SortKeyDelegate
+        val hashKey = HashKeySubstitute
+        val sortKey = SortKeySubstitute
 
         @Deprecated(
             "Use the special value 'hashKey' in place of the hash key attribute",
@@ -63,7 +63,7 @@ class DynamoDbScanAndQueryBuilder<HashKey : Any, SortKey : Any>(
             }
         }
 
-        infix fun HashKeyDelegate.eq(value: HashKey) = nextAttributeName().let { attributeName ->
+        infix fun HashKeySubstitute.eq(value: HashKey) = nextAttributeName().let { attributeName ->
             object : PartitionKeyCondition<HashKey, SortKey> {
                 override val expression = "#$attributeName = :$attributeName"
                 override val attributeNames = mapOf("#$attributeName" to hashKeyAttribute.name)
@@ -90,7 +90,7 @@ class DynamoDbScanAndQueryBuilder<HashKey : Any, SortKey : Any>(
                 )
             }
 
-        private fun SortKeyDelegate.sortKeyOperator(op: String, value: SortKey): SortKeyCondition<HashKey, SortKey>? =
+        private fun SortKeySubstitute.sortKeyOperator(op: String, value: SortKey): SortKeyCondition<HashKey, SortKey>? =
             sortKeyAttribute?.let {
                 nextAttributeName().let { attributeName ->
                     sortKeyCondition(
@@ -124,11 +124,11 @@ class DynamoDbScanAndQueryBuilder<HashKey : Any, SortKey : Any>(
             replaceWith = ReplaceWith("sortKey ge value")
         )
         infix fun Attribute<SortKey>.ge(value: SortKey) = sortKeyOperator(">=", value)
-        infix fun SortKeyDelegate.eq(value: SortKey) = sortKeyOperator("=", value)
-        infix fun SortKeyDelegate.lt(value: SortKey) = sortKeyOperator("<", value)
-        infix fun SortKeyDelegate.le(value: SortKey) = sortKeyOperator("<=", value)
-        infix fun SortKeyDelegate.gt(value: SortKey) = sortKeyOperator(">", value)
-        infix fun SortKeyDelegate.ge(value: SortKey) = sortKeyOperator(">=", value)
+        infix fun SortKeySubstitute.eq(value: SortKey) = sortKeyOperator("=", value)
+        infix fun SortKeySubstitute.lt(value: SortKey) = sortKeyOperator("<", value)
+        infix fun SortKeySubstitute.le(value: SortKey) = sortKeyOperator("<=", value)
+        infix fun SortKeySubstitute.gt(value: SortKey) = sortKeyOperator(">", value)
+        infix fun SortKeySubstitute.ge(value: SortKey) = sortKeyOperator(">=", value)
 
         @Deprecated(
             "Use the special value 'sortKey' in place of the sort key attribute",
@@ -143,7 +143,7 @@ class DynamoDbScanAndQueryBuilder<HashKey : Any, SortKey : Any>(
                 )
             }
 
-        fun SortKeyDelegate.between(value1: SortKey, value2: SortKey): SortKeyCondition<HashKey, SortKey>? =
+        fun SortKeySubstitute.between(value1: SortKey, value2: SortKey): SortKeyCondition<HashKey, SortKey>? =
             sortKeyAttribute?.let {
                 nextAttributeName().let { attributeName ->
                     sortKeyCondition(
@@ -169,7 +169,7 @@ class DynamoDbScanAndQueryBuilder<HashKey : Any, SortKey : Any>(
             )
         }
 
-        infix fun SortKeyDelegate.beginsWith(value: SortKey): SortKeyCondition<HashKey, SortKey>? =
+        infix fun SortKeySubstitute.beginsWith(value: SortKey): SortKeyCondition<HashKey, SortKey>? =
             sortKeyAttribute?.let {
                 nextAttributeName().let { attributeName ->
                     sortKeyCondition(

--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryDsl.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryDsl.kt
@@ -2,6 +2,7 @@ package org.http4k.connect.amazon.dynamodb.mapper
 
 import org.http4k.connect.amazon.dynamodb.model.Attribute
 import org.http4k.connect.amazon.dynamodb.model.AttributeValue
+import org.http4k.connect.amazon.dynamodb.model.Key
 import org.http4k.connect.amazon.dynamodb.model.TokensToNames
 import org.http4k.connect.amazon.dynamodb.model.TokensToValues
 
@@ -351,5 +352,89 @@ class DynamoDbQueryBuilder<HashKey : Any, SortKey : Any>(private val schema: Dyn
             keyCondition?.attributeValues,
             filterExpression?.attributeValues
         )
+    )
+}
+
+fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document, HashKey, SortKey>.scan(
+    PageSize: Int? = null,
+    ConsistentRead: Boolean? = null,
+    block: DynamoDbScanBuilder.() -> Unit
+): Sequence<Document> {
+    val scan = DynamoDbScanBuilder().apply(block).build()
+    return scan(
+        FilterExpression = scan.filterExpression,
+        ExpressionAttributeNames = scan.expressionAttributeNames,
+        ExpressionAttributeValues = scan.expressionAttributeValues,
+        PageSize = PageSize,
+        ConsistentRead = ConsistentRead
+    )
+}
+
+fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document, HashKey, SortKey>.scanPage(
+    ExclusiveStartKey: Key? = null,
+    Limit: Int? = null,
+    ConsistentRead: Boolean? = null,
+    block: DynamoDbScanBuilder.() -> Unit
+): DynamoDbPage<Document> {
+    val scan = DynamoDbScanBuilder().apply(block).build()
+    return scanPage(
+        FilterExpression = scan.filterExpression,
+        ExpressionAttributeNames = scan.expressionAttributeNames,
+        ExpressionAttributeValues = scan.expressionAttributeValues,
+        ExclusiveStartKey = ExclusiveStartKey,
+        Limit = Limit,
+        ConsistentRead = ConsistentRead
+    )
+}
+
+fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document, HashKey, SortKey>.query(
+    ScanIndexForward: Boolean = true,
+    PageSize: Int? = null,
+    ConsistentRead: Boolean? = null,
+    block: DynamoDbQueryBuilder<HashKey, SortKey>.() -> Unit
+): Sequence<Document> {
+    val query = DynamoDbQueryBuilder(schema).apply(block).build()
+    return query(
+        KeyConditionExpression = query.keyConditionExpression,
+        FilterExpression = query.filterExpression,
+        ExpressionAttributeNames = query.expressionAttributeNames,
+        ExpressionAttributeValues = query.expressionAttributeValues,
+        ScanIndexForward = ScanIndexForward,
+        PageSize = PageSize,
+        ConsistentRead = ConsistentRead
+    )
+}
+
+fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document, HashKey, SortKey>.queryPage(
+    ScanIndexForward: Boolean = true,
+    Limit: Int? = null,
+    ConsistentRead: Boolean? = null,
+    ExclusiveStartKey: Key? = null,
+    block: DynamoDbQueryBuilder<HashKey, SortKey>.() -> Unit
+): DynamoDbPage<Document> {
+    val query = DynamoDbQueryBuilder(schema).apply(block).build()
+    return queryPage(
+        KeyConditionExpression = query.keyConditionExpression,
+        FilterExpression = query.filterExpression,
+        ExpressionAttributeNames = query.expressionAttributeNames,
+        ExpressionAttributeValues = query.expressionAttributeValues,
+        ExclusiveStartKey = ExclusiveStartKey,
+        ScanIndexForward = ScanIndexForward,
+        Limit = Limit,
+        ConsistentRead = ConsistentRead
+    )
+}
+
+fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document, HashKey, SortKey>.count(
+    ConsistentRead: Boolean? = null,
+    block: DynamoDbQueryBuilder<HashKey, SortKey>.() -> Unit
+): Int {
+    val query = DynamoDbQueryBuilder(schema).apply(block).build()
+    return count(
+        KeyConditionExpression = query.keyConditionExpression,
+        FilterExpression = query.filterExpression,
+        ExpressionAttributeNames = query.expressionAttributeNames,
+        ExpressionAttributeValues = query.expressionAttributeValues,
+        ConsistentRead = ConsistentRead
     )
 }

--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryDsl.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryDsl.kt
@@ -353,11 +353,8 @@ class DynamoDbScanAndQueryBuilder<HashKey : Any, SortKey : Any>(
     internal val filterExpression: FilterExpression? get() = _filterExpression
 }
 
-class DynamoDbScanBuilder<HashKey : Any, SortKey : Any>(
-    hashKeyAttribute: Attribute<HashKey>,
-    sortKeyAttribute: Attribute<SortKey>?
-) {
-    private val delegate = DynamoDbScanAndQueryBuilder(hashKeyAttribute, sortKeyAttribute)
+class DynamoDbScanBuilder<HashKey : Any, SortKey : Any>(schema: DynamoDbTableMapperSchema<HashKey, SortKey>) {
+    private val delegate = DynamoDbScanAndQueryBuilder(schema.hashKeyAttribute, schema.sortKeyAttribute)
 
     fun filterExpression(block: DynamoDbScanAndQueryBuilder<HashKey, SortKey>.FilterExpressionBuilder.() -> FilterExpression?) =
         delegate.filterExpression(block)
@@ -369,12 +366,9 @@ class DynamoDbScanBuilder<HashKey : Any, SortKey : Any>(
     )
 }
 
-class DynamoDbQueryBuilder<HashKey : Any, SortKey : Any>(
-    hashKeyAttribute: Attribute<HashKey>,
-    sortKeyAttribute: Attribute<SortKey>?
-) {
+class DynamoDbQueryBuilder<HashKey : Any, SortKey : Any>(schema: DynamoDbTableMapperSchema<HashKey, SortKey>) {
 
-    private val delegate = DynamoDbScanAndQueryBuilder(hashKeyAttribute, sortKeyAttribute)
+    private val delegate = DynamoDbScanAndQueryBuilder(schema.hashKeyAttribute, schema.sortKeyAttribute)
 
     fun keyCondition(block: DynamoDbScanAndQueryBuilder<HashKey, SortKey>.KeyConditionBuilder.() -> CombinedKeyCondition<HashKey, SortKey>) =
         delegate.keyCondition(block)
@@ -407,7 +401,7 @@ fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document,
     ConsistentRead: Boolean? = null,
     block: DynamoDbScanBuilder<HashKey, SortKey>.() -> Unit
 ): Sequence<Document> {
-    val filter = DynamoDbScanBuilder(hashKeyAttribute, sortKeyAttribute).apply(block).build()
+    val filter = DynamoDbScanBuilder(schema).apply(block).build()
     return scan(
         FilterExpression = filter.filterExpression,
         ExpressionAttributeNames = filter.expressionAttributeNames,
@@ -423,7 +417,7 @@ fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document,
     ConsistentRead: Boolean? = null,
     block: DynamoDbScanBuilder<HashKey, SortKey>.() -> Unit
 ): DynamoDbPage<Document> {
-    val filter = DynamoDbScanBuilder(hashKeyAttribute, sortKeyAttribute).apply(block).build()
+    val filter = DynamoDbScanBuilder(schema).apply(block).build()
     return scanPage(
         FilterExpression = filter.filterExpression,
         ExpressionAttributeNames = filter.expressionAttributeNames,
@@ -440,7 +434,7 @@ fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document,
     ConsistentRead: Boolean? = null,
     block: DynamoDbQueryBuilder<HashKey, SortKey>.() -> Unit
 ): Sequence<Document> {
-    val query = DynamoDbQueryBuilder(hashKeyAttribute, sortKeyAttribute).apply(block).build()
+    val query = DynamoDbQueryBuilder(schema).apply(block).build()
     return query(
         KeyConditionExpression = query.keyConditionExpression,
         FilterExpression = query.filterExpression,
@@ -459,7 +453,7 @@ fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document,
     ExclusiveStartKey: Key? = null,
     block: DynamoDbQueryBuilder<HashKey, SortKey>.() -> Unit
 ): DynamoDbPage<Document> {
-    val query = DynamoDbQueryBuilder(hashKeyAttribute, sortKeyAttribute).apply(block).build()
+    val query = DynamoDbQueryBuilder(schema).apply(block).build()
     return queryPage(
         KeyConditionExpression = query.keyConditionExpression,
         FilterExpression = query.filterExpression,
@@ -476,7 +470,7 @@ fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document,
     ConsistentRead: Boolean? = null,
     block: DynamoDbQueryBuilder<HashKey, SortKey>.() -> Unit
 ): Int {
-    val query = DynamoDbQueryBuilder(hashKeyAttribute, sortKeyAttribute).apply(block).build()
+    val query = DynamoDbQueryBuilder(schema).apply(block).build()
     return count(
         KeyConditionExpression = query.keyConditionExpression,
         FilterExpression = query.filterExpression,

--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryDsl.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryDsl.kt
@@ -13,8 +13,7 @@ interface KeyCondition<HashKey : Any, SortKey : Any> {
 
 interface SortKeyCondition<HashKey : Any, SortKey : Any> : KeyCondition<HashKey, SortKey>
 interface CombinedKeyCondition<HashKey : Any, SortKey : Any> : KeyCondition<HashKey, SortKey>
-interface PartitionKeyCondition<HashKey : Any, SortKey : Any> : SortKeyCondition<HashKey, SortKey>,
-    CombinedKeyCondition<HashKey, SortKey>
+interface PartitionKeyCondition<HashKey : Any, SortKey : Any> : CombinedKeyCondition<HashKey, SortKey>
 
 /**
  * See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.KeyConditionExpressions.html

--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryDsl.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryDsl.kt
@@ -2,7 +2,6 @@ package org.http4k.connect.amazon.dynamodb.mapper
 
 import org.http4k.connect.amazon.dynamodb.model.Attribute
 import org.http4k.connect.amazon.dynamodb.model.AttributeValue
-import org.http4k.connect.amazon.dynamodb.model.Key
 import org.http4k.connect.amazon.dynamodb.model.TokensToNames
 import org.http4k.connect.amazon.dynamodb.model.TokensToValues
 
@@ -353,89 +352,5 @@ class DynamoDbQueryBuilder<HashKey : Any, SortKey : Any>(private val schema: Dyn
             keyCondition?.attributeValues,
             filterExpression?.attributeValues
         )
-    )
-}
-
-fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document, HashKey, SortKey>.scan(
-    PageSize: Int? = null,
-    ConsistentRead: Boolean? = null,
-    block: DynamoDbScanBuilder.() -> Unit
-): Sequence<Document> {
-    val scan = DynamoDbScanBuilder().apply(block).build()
-    return scan(
-        FilterExpression = scan.filterExpression,
-        ExpressionAttributeNames = scan.expressionAttributeNames,
-        ExpressionAttributeValues = scan.expressionAttributeValues,
-        PageSize = PageSize,
-        ConsistentRead = ConsistentRead
-    )
-}
-
-fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document, HashKey, SortKey>.scanPage(
-    ExclusiveStartKey: Key? = null,
-    Limit: Int? = null,
-    ConsistentRead: Boolean? = null,
-    block: DynamoDbScanBuilder.() -> Unit
-): DynamoDbPage<Document> {
-    val scan = DynamoDbScanBuilder().apply(block).build()
-    return scanPage(
-        FilterExpression = scan.filterExpression,
-        ExpressionAttributeNames = scan.expressionAttributeNames,
-        ExpressionAttributeValues = scan.expressionAttributeValues,
-        ExclusiveStartKey = ExclusiveStartKey,
-        Limit = Limit,
-        ConsistentRead = ConsistentRead
-    )
-}
-
-fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document, HashKey, SortKey>.query(
-    ScanIndexForward: Boolean = true,
-    PageSize: Int? = null,
-    ConsistentRead: Boolean? = null,
-    block: DynamoDbQueryBuilder<HashKey, SortKey>.() -> Unit
-): Sequence<Document> {
-    val query = DynamoDbQueryBuilder(schema).apply(block).build()
-    return query(
-        KeyConditionExpression = query.keyConditionExpression,
-        FilterExpression = query.filterExpression,
-        ExpressionAttributeNames = query.expressionAttributeNames,
-        ExpressionAttributeValues = query.expressionAttributeValues,
-        ScanIndexForward = ScanIndexForward,
-        PageSize = PageSize,
-        ConsistentRead = ConsistentRead
-    )
-}
-
-fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document, HashKey, SortKey>.queryPage(
-    ScanIndexForward: Boolean = true,
-    Limit: Int? = null,
-    ConsistentRead: Boolean? = null,
-    ExclusiveStartKey: Key? = null,
-    block: DynamoDbQueryBuilder<HashKey, SortKey>.() -> Unit
-): DynamoDbPage<Document> {
-    val query = DynamoDbQueryBuilder(schema).apply(block).build()
-    return queryPage(
-        KeyConditionExpression = query.keyConditionExpression,
-        FilterExpression = query.filterExpression,
-        ExpressionAttributeNames = query.expressionAttributeNames,
-        ExpressionAttributeValues = query.expressionAttributeValues,
-        ExclusiveStartKey = ExclusiveStartKey,
-        ScanIndexForward = ScanIndexForward,
-        Limit = Limit,
-        ConsistentRead = ConsistentRead
-    )
-}
-
-fun <Document : Any, HashKey : Any, SortKey : Any> DynamoDbIndexMapper<Document, HashKey, SortKey>.count(
-    ConsistentRead: Boolean? = null,
-    block: DynamoDbQueryBuilder<HashKey, SortKey>.() -> Unit
-): Int {
-    val query = DynamoDbQueryBuilder(schema).apply(block).build()
-    return count(
-        KeyConditionExpression = query.keyConditionExpression,
-        FilterExpression = query.filterExpression,
-        ExpressionAttributeNames = query.expressionAttributeNames,
-        ExpressionAttributeValues = query.expressionAttributeValues,
-        ConsistentRead = ConsistentRead
     )
 }

--- a/amazon/dynamodb/client/src/test/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryDslTest.kt
+++ b/amazon/dynamodb/client/src/test/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryDslTest.kt
@@ -76,9 +76,9 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Scan, present(
                     allOf(
-                        scanHasFilterExpression("#a = :a"),
-                        scanHasAttributeNames(mapOf("#a" to sortKeyAttr.name)),
-                        scanHasAttributeValues(mapOf(":a" to sortKeyAttr.asValue("bar"))),
+                        scanHasFilterExpression("#fa = :fa"),
+                        scanHasAttributeNames(mapOf("#fa" to sortKeyAttr.name)),
+                        scanHasAttributeValues(mapOf(":fa" to sortKeyAttr.asValue("bar"))),
                         scanHasLimit(20),
                         scanHasConsistentRead(true)
                     )
@@ -99,9 +99,9 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Scan, present(
                     allOf(
-                        scanHasFilterExpression("#a <> :a"),
-                        scanHasAttributeNames(mapOf("#a" to hashKeyAttr.name)),
-                        scanHasAttributeValues(mapOf(":a" to hashKeyAttr.asValue(uuid))),
+                        scanHasFilterExpression("#fa <> :fa"),
+                        scanHasAttributeNames(mapOf("#fa" to hashKeyAttr.name)),
+                        scanHasAttributeValues(mapOf(":fa" to hashKeyAttr.asValue(uuid))),
                         scanHasLimit(null),
                         scanHasConsistentRead(null)
                     )
@@ -122,9 +122,9 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Scan, present(
                     allOf(
-                        scanHasFilterExpression("#a > :a"),
-                        scanHasAttributeNames(mapOf("#a" to sortKeyAttr.name)),
-                        scanHasAttributeValues(mapOf(":a" to sortKeyAttr.asValue("baz")))
+                        scanHasFilterExpression("#fa > :fa"),
+                        scanHasAttributeNames(mapOf("#fa" to sortKeyAttr.name)),
+                        scanHasAttributeValues(mapOf(":fa" to sortKeyAttr.asValue("baz")))
                     )
                 )
             )
@@ -143,9 +143,9 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Scan, present(
                     allOf(
-                        scanHasFilterExpression("#a >= :a"),
-                        scanHasAttributeNames(mapOf("#a" to sortKeyAttr.name)),
-                        scanHasAttributeValues(mapOf(":a" to sortKeyAttr.asValue("baz")))
+                        scanHasFilterExpression("#fa >= :fa"),
+                        scanHasAttributeNames(mapOf("#fa" to sortKeyAttr.name)),
+                        scanHasAttributeValues(mapOf(":fa" to sortKeyAttr.asValue("baz")))
                     )
                 )
             )
@@ -164,9 +164,9 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Scan, present(
                     allOf(
-                        scanHasFilterExpression("#a < :a"),
-                        scanHasAttributeNames(mapOf("#a" to intAttr.name)),
-                        scanHasAttributeValues(mapOf(":a" to intAttr.asValue(5)))
+                        scanHasFilterExpression("#fa < :fa"),
+                        scanHasAttributeNames(mapOf("#fa" to intAttr.name)),
+                        scanHasAttributeValues(mapOf(":fa" to intAttr.asValue(5)))
                     )
                 )
             )
@@ -185,9 +185,9 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Scan, present(
                     allOf(
-                        scanHasFilterExpression("#a <= :a"),
-                        scanHasAttributeNames(mapOf("#a" to intAttr.name)),
-                        scanHasAttributeValues(mapOf(":a" to intAttr.asValue(17)))
+                        scanHasFilterExpression("#fa <= :fa"),
+                        scanHasAttributeNames(mapOf("#fa" to intAttr.name)),
+                        scanHasAttributeValues(mapOf(":fa" to intAttr.asValue(17)))
                     )
                 )
             )
@@ -206,8 +206,8 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Scan, present(
                     allOf(
-                        scanHasFilterExpression("#a = #b"),
-                        scanHasAttributeNames(mapOf("#a" to intAttr.name, "#b" to anotherIntAttr.name)),
+                        scanHasFilterExpression("#fa = #fb"),
+                        scanHasAttributeNames(mapOf("#fa" to intAttr.name, "#fb" to anotherIntAttr.name)),
                         scanHasAttributeValues(emptyMap())
                     )
                 )
@@ -227,12 +227,12 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Scan, present(
                     allOf(
-                        scanHasFilterExpression("#a BETWEEN :a1 AND :a2"),
-                        scanHasAttributeNames(mapOf("#a" to intAttr.name)),
+                        scanHasFilterExpression("#fa BETWEEN :fa1 AND :fa2"),
+                        scanHasAttributeNames(mapOf("#fa" to intAttr.name)),
                         scanHasAttributeValues(
                             mapOf(
-                                ":a1" to intAttr.asValue(17),
-                                ":a2" to intAttr.asValue(23)
+                                ":fa1" to intAttr.asValue(17),
+                                ":fa2" to intAttr.asValue(23)
                             )
                         )
                     )
@@ -253,14 +253,14 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Scan, present(
                     allOf(
-                        scanHasFilterExpression("#a IN (:a0,:a1,:a2,:a3)"),
-                        scanHasAttributeNames(mapOf("#a" to intAttr.name)),
+                        scanHasFilterExpression("#fa IN (:fa0,:fa1,:fa2,:fa3)"),
+                        scanHasAttributeNames(mapOf("#fa" to intAttr.name)),
                         scanHasAttributeValues(
                             mapOf(
-                                ":a0" to intAttr.asValue(3),
-                                ":a1" to intAttr.asValue(5),
-                                ":a2" to intAttr.asValue(8),
-                                ":a3" to intAttr.asValue(13),
+                                ":fa0" to intAttr.asValue(3),
+                                ":fa1" to intAttr.asValue(5),
+                                ":fa2" to intAttr.asValue(8),
+                                ":fa3" to intAttr.asValue(13),
                             )
                         )
                     )
@@ -281,8 +281,8 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Scan, present(
                     allOf(
-                        scanHasFilterExpression("attribute_exists(#a)"),
-                        scanHasAttributeNames(mapOf("#a" to intAttr.name)),
+                        scanHasFilterExpression("attribute_exists(#fa)"),
+                        scanHasAttributeNames(mapOf("#fa" to intAttr.name)),
                         scanHasAttributeValues(emptyMap()),
                     )
                 )
@@ -302,8 +302,8 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Scan, present(
                     allOf(
-                        scanHasFilterExpression("attribute_not_exists(#a)"),
-                        scanHasAttributeNames(mapOf("#a" to intAttr.name)),
+                        scanHasFilterExpression("attribute_not_exists(#fa)"),
+                        scanHasAttributeNames(mapOf("#fa" to intAttr.name)),
                         scanHasAttributeValues(emptyMap()),
                     )
                 )
@@ -323,9 +323,9 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Scan, present(
                     allOf(
-                        scanHasFilterExpression("begins_with(#a,:a)"),
-                        scanHasAttributeNames(mapOf("#a" to sortKeyAttr.name)),
-                        scanHasAttributeValues(mapOf(":a" to sortKeyAttr.asValue("A"))),
+                        scanHasFilterExpression("begins_with(#fa,:fa)"),
+                        scanHasAttributeNames(mapOf("#fa" to sortKeyAttr.name)),
+                        scanHasAttributeValues(mapOf(":fa" to sortKeyAttr.asValue("A"))),
                     )
                 )
             )
@@ -344,9 +344,9 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Scan, present(
                     allOf(
-                        scanHasFilterExpression("contains(#a,:a)"),
-                        scanHasAttributeNames(mapOf("#a" to sortKeyAttr.name)),
-                        scanHasAttributeValues(mapOf(":a" to sortKeyAttr.asValue("X")))
+                        scanHasFilterExpression("contains(#fa,:fa)"),
+                        scanHasAttributeNames(mapOf("#fa" to sortKeyAttr.name)),
+                        scanHasAttributeValues(mapOf(":fa" to sortKeyAttr.asValue("X")))
                     )
                 )
             )
@@ -366,21 +366,21 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Scan, present(
                     allOf(
-                        scanHasFilterExpression("((#a <> :a AND (NOT begins_with(#b,:b))) OR (attribute_exists(#c) AND #d BETWEEN :d1 AND :d2))"),
+                        scanHasFilterExpression("((#fa <> :fa AND (NOT begins_with(#fb,:fb))) OR (attribute_exists(#fc) AND #fd BETWEEN :fd1 AND :fd2))"),
                         scanHasAttributeNames(
                             mapOf(
-                                "#a" to hashKeyAttr.name,
-                                "#b" to sortKeyAttr.name,
-                                "#c" to intAttr.name,
-                                "#d" to intAttr.name
+                                "#fa" to hashKeyAttr.name,
+                                "#fb" to sortKeyAttr.name,
+                                "#fc" to intAttr.name,
+                                "#fd" to intAttr.name
                             )
                         ),
                         scanHasAttributeValues(
                             mapOf(
-                                ":a" to hashKeyAttr.asValue(uuid),
-                                ":b" to sortKeyAttr.asValue("A"),
-                                ":d1" to intAttr.asValue(100),
-                                ":d2" to intAttr.asValue(200)
+                                ":fa" to hashKeyAttr.asValue(uuid),
+                                ":fb" to sortKeyAttr.asValue("A"),
+                                ":fd1" to intAttr.asValue(100),
+                                ":fd2" to intAttr.asValue(200)
                             )
                         )
                     )
@@ -405,9 +405,9 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Scan, present(
                     allOf(
-                        scanHasFilterExpression("(#a = :a AND (begins_with(#b,:b) OR attribute_exists(#c)))"),
-                        scanHasAttributeNames(mapOf("#a" to hashKeyAttr.name, "#b" to sortKeyAttr.name, "#c" to intAttr.name)),
-                        scanHasAttributeValues(mapOf(":a" to hashKeyAttr.asValue(uuid), ":b" to sortKeyAttr.asValue("foo"))),
+                        scanHasFilterExpression("(#fa = :fa AND (begins_with(#fb,:fb) OR attribute_exists(#fc)))"),
+                        scanHasAttributeNames(mapOf("#fa" to hashKeyAttr.name, "#fb" to sortKeyAttr.name, "#fc" to intAttr.name)),
+                        scanHasAttributeValues(mapOf(":fa" to hashKeyAttr.asValue(uuid), ":fb" to sortKeyAttr.asValue("foo"))),
                         scanHasExclusiveStartKey(Item().with(hashKeyAttr of uuid, sortKeyAttr of "B")),
                         scanHasLimit(20),
                         scanHasConsistentRead(true)
@@ -433,10 +433,10 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Query, present(
                     allOf(
-                        queryHasKeyConditionExpression("#a = :a"),
+                        queryHasKeyConditionExpression("#hk = :hk"),
                         queryHasFilterExpression(null),
-                        queryHasAttributeNames(mapOf("#a" to hashKeyAttr.name)),
-                        queryHasAttributeValues(mapOf(":a" to hashKeyAttr.asValue(uuid))),
+                        queryHasAttributeNames(mapOf("#hk" to hashKeyAttr.name)),
+                        queryHasAttributeValues(mapOf(":hk" to hashKeyAttr.asValue(uuid))),
                         queryHasScanIndexForward(false),
                         queryHasLimit(10),
                         queryHasConsistentRead(true)
@@ -458,10 +458,10 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Query, present(
                     allOf(
-                        queryHasKeyConditionExpression("#a = :a"),
+                        queryHasKeyConditionExpression("#hk = :hk"),
                         queryHasFilterExpression(null),
-                        queryHasAttributeNames(mapOf("#a" to intAttr.name)),
-                        queryHasAttributeValues(mapOf(":a" to intAttr.asValue(7)))
+                        queryHasAttributeNames(mapOf("#hk" to intAttr.name)),
+                        queryHasAttributeValues(mapOf(":hk" to intAttr.asValue(7)))
                     )
                 )
             )
@@ -480,10 +480,10 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Query, present(
                     allOf(
-                        queryHasKeyConditionExpression("#a = :a"),
+                        queryHasKeyConditionExpression("#hk = :hk"),
                         queryHasFilterExpression(null),
-                        queryHasAttributeNames(mapOf("#a" to hashKeyAttr.name)),
-                        queryHasAttributeValues(mapOf(":a" to hashKeyAttr.asValue(uuid))),
+                        queryHasAttributeNames(mapOf("#hk" to hashKeyAttr.name)),
+                        queryHasAttributeValues(mapOf(":hk" to hashKeyAttr.asValue(uuid))),
                         queryHasScanIndexForward(true), // default
                         queryHasLimit(null),
                         queryHasConsistentRead(null)
@@ -505,10 +505,10 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Query, present(
                     allOf(
-                        queryHasKeyConditionExpression("#a = :a"),
+                        queryHasKeyConditionExpression("#hk = :hk"),
                         queryHasFilterExpression(null),
-                        queryHasAttributeNames(mapOf("#a" to intAttr.name)),
-                        queryHasAttributeValues(mapOf(":a" to intAttr.asValue(7)))
+                        queryHasAttributeNames(mapOf("#hk" to intAttr.name)),
+                        queryHasAttributeValues(mapOf(":hk" to intAttr.asValue(7)))
                     )
                 )
             )
@@ -527,10 +527,10 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Query, present(
                     allOf(
-                        queryHasKeyConditionExpression("#a = :a AND #b < :b"),
+                        queryHasKeyConditionExpression("#hk = :hk AND #sk < :sk"),
                         queryHasFilterExpression(null),
-                        queryHasAttributeNames(mapOf("#a" to hashKeyAttr.name, "#b" to sortKeyAttr.name)),
-                        queryHasAttributeValues(mapOf(":a" to hashKeyAttr.asValue(uuid), ":b" to sortKeyAttr.asValue("B")))
+                        queryHasAttributeNames(mapOf("#hk" to hashKeyAttr.name, "#sk" to sortKeyAttr.name)),
+                        queryHasAttributeValues(mapOf(":hk" to hashKeyAttr.asValue(uuid), ":sk" to sortKeyAttr.asValue("B")))
                     )
                 )
             )
@@ -549,14 +549,14 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Query, present(
                     allOf(
-                        queryHasKeyConditionExpression("#a = :a AND #b BETWEEN :b1 AND :b2"),
+                        queryHasKeyConditionExpression("#hk = :hk AND #sk BETWEEN :sk1 AND :sk2"),
                         queryHasFilterExpression(null),
-                        queryHasAttributeNames(mapOf("#a" to hashKeyAttr.name, "#b" to sortKeyAttr.name)),
+                        queryHasAttributeNames(mapOf("#hk" to hashKeyAttr.name, "#sk" to sortKeyAttr.name)),
                         queryHasAttributeValues(
                             mapOf(
-                                ":a" to hashKeyAttr.asValue(uuid),
-                                ":b1" to sortKeyAttr.asValue("a"),
-                                ":b2" to sortKeyAttr.asValue("h")
+                                ":hk" to hashKeyAttr.asValue(uuid),
+                                ":sk1" to sortKeyAttr.asValue("a"),
+                                ":sk2" to sortKeyAttr.asValue("h")
                             )
                         )
                     )
@@ -577,10 +577,10 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Query, present(
                     allOf(
-                        queryHasKeyConditionExpression("#a = :a AND begins_with(#b,:b)"),
+                        queryHasKeyConditionExpression("#hk = :hk AND begins_with(#sk,:sk)"),
                         queryHasFilterExpression(null),
-                        queryHasAttributeNames(mapOf("#a" to hashKeyAttr.name, "#b" to sortKeyAttr.name)),
-                        queryHasAttributeValues(mapOf(":a" to hashKeyAttr.asValue(uuid), ":b" to sortKeyAttr.asValue("S")))
+                        queryHasAttributeNames(mapOf("#hk" to hashKeyAttr.name, "#sk" to sortKeyAttr.name)),
+                        queryHasAttributeValues(mapOf(":hk" to hashKeyAttr.asValue(uuid), ":sk" to sortKeyAttr.asValue("S")))
                     )
                 )
             )
@@ -602,21 +602,21 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Query, present(
                     allOf(
-                        queryHasKeyConditionExpression("#a = :a AND #b > :b"),
-                        queryHasFilterExpression("(attribute_not_exists(#c) OR #d = :d)"),
+                        queryHasKeyConditionExpression("#hk = :hk AND #sk > :sk"),
+                        queryHasFilterExpression("(attribute_not_exists(#fa) OR #fb = :fb)"),
                         queryHasAttributeNames(
                             mapOf(
-                                "#a" to hashKeyAttr.name,
-                                "#b" to sortKeyAttr.name,
-                                "#c" to intAttr.name,
-                                "#d" to intAttr.name,
+                                "#hk" to hashKeyAttr.name,
+                                "#sk" to sortKeyAttr.name,
+                                "#fa" to intAttr.name,
+                                "#fb" to intAttr.name,
                             )
                         ),
                         queryHasAttributeValues(
                             mapOf(
-                                ":a" to hashKeyAttr.asValue(uuid),
-                                ":b" to sortKeyAttr.asValue("A"),
-                                ":d" to intAttr.asValue(0)
+                                ":hk" to hashKeyAttr.asValue(uuid),
+                                ":sk" to sortKeyAttr.asValue("A"),
+                                ":fb" to intAttr.asValue(0)
                             )
                         )
                     )
@@ -645,23 +645,23 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Query, present(
                     allOf(
-                        queryHasKeyConditionExpression("#a = :a AND #b >= :b"),
-                        queryHasFilterExpression("((attribute_not_exists(#c) OR #d = :d) OR #e <> #f)"),
+                        queryHasKeyConditionExpression("#hk = :hk AND #sk >= :sk"),
+                        queryHasFilterExpression("((attribute_not_exists(#fa) OR #fb = :fb) OR #fc <> #fd)"),
                         queryHasAttributeNames(
                             mapOf(
-                                "#a" to hashKeyAttr.name,
-                                "#b" to sortKeyAttr.name,
-                                "#c" to intAttr.name,
-                                "#d" to intAttr.name,
-                                "#e" to intAttr.name,
-                                "#f" to anotherIntAttr.name,
+                                "#hk" to hashKeyAttr.name,
+                                "#sk" to sortKeyAttr.name,
+                                "#fa" to intAttr.name,
+                                "#fb" to intAttr.name,
+                                "#fc" to intAttr.name,
+                                "#fd" to anotherIntAttr.name,
                             )
                         ),
                         queryHasAttributeValues(
                             mapOf(
-                                ":a" to hashKeyAttr.asValue(uuid),
-                                ":b" to sortKeyAttr.asValue("A"),
-                                ":d" to intAttr.asValue(0)
+                                ":hk" to hashKeyAttr.asValue(uuid),
+                                ":sk" to sortKeyAttr.asValue("A"),
+                                ":fb" to intAttr.asValue(0)
                             )
                         ),
                         queryHasScanIndexForward(false),
@@ -689,20 +689,20 @@ class DynamoDbQueryDslTest {
             assertThat(
                 mockDynamoDb.action as? Query, present(
                     allOf(
-                        queryHasKeyConditionExpression("#a = :a AND #b = :b"),
-                        queryHasFilterExpression("#c > #d"),
+                        queryHasKeyConditionExpression("#hk = :hk AND #sk = :sk"),
+                        queryHasFilterExpression("#fa > #fb"),
                         queryHasAttributeNames(
                             mapOf(
-                                "#a" to hashKeyAttr.name,
-                                "#b" to sortKeyAttr.name,
-                                "#c" to intAttr.name,
-                                "#d" to anotherIntAttr.name
+                                "#hk" to hashKeyAttr.name,
+                                "#sk" to sortKeyAttr.name,
+                                "#fa" to intAttr.name,
+                                "#fb" to anotherIntAttr.name
                             )
                         ),
                         queryHasAttributeValues(
                             mapOf(
-                                ":a" to hashKeyAttr.asValue(uuid),
-                                ":b" to sortKeyAttr.asValue("A")
+                                ":hk" to hashKeyAttr.asValue(uuid),
+                                ":sk" to sortKeyAttr.asValue("A")
                             )
                         ),
                         queryHasSelect(Select.COUNT)
@@ -719,23 +719,23 @@ class DynamoDbQueryDslTest {
             Arguments.of(
                 42,
                 null,
-                "#a = :a",
-                mapOf("#a" to intAttr.name),
-                mapOf(":a" to intAttr.asValue(42))
+                "#fa = :fa",
+                mapOf("#fa" to intAttr.name),
+                mapOf(":fa" to intAttr.asValue(42))
             ),
             Arguments.of(
                 null,
                 "foo",
-                "#a = :a",
-                mapOf("#a" to stringAttr.name),
-                mapOf(":a" to stringAttr.asValue("foo"))
+                "#fa = :fa",
+                mapOf("#fa" to stringAttr.name),
+                mapOf(":fa" to stringAttr.asValue("foo"))
             ),
             Arguments.of(
                 42,
                 "foo",
-                "(#a = :a AND #b = :b)",
-                mapOf("#a" to intAttr.name, "#b" to stringAttr.name),
-                mapOf(":a" to intAttr.asValue(42), ":b" to stringAttr.asValue("foo"))
+                "(#fa = :fa AND #fb = :fb)",
+                mapOf("#fa" to intAttr.name, "#fb" to stringAttr.name),
+                mapOf(":fa" to intAttr.asValue(42), ":fb" to stringAttr.asValue("foo"))
             )
         )
     }

--- a/amazon/dynamodb/client/src/test/kotlin/org/http4k/connect/amazon/dynamodb/mapper/queryMatchers.kt
+++ b/amazon/dynamodb/client/src/test/kotlin/org/http4k/connect/amazon/dynamodb/mapper/queryMatchers.kt
@@ -4,6 +4,7 @@ import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.has
 import org.http4k.connect.amazon.dynamodb.action.Query
 import org.http4k.connect.amazon.dynamodb.model.Key
+import org.http4k.connect.amazon.dynamodb.model.Select
 import org.http4k.connect.amazon.dynamodb.model.TokensToNames
 import org.http4k.connect.amazon.dynamodb.model.TokensToValues
 
@@ -29,3 +30,5 @@ fun queryHasConsistentRead(value: Boolean?) =
 
 fun queryHasScanIndexForward(value: Boolean?) =
     has("ScanIndexForward", { query: Query -> query.ScanIndexForward }, equalTo(value))
+
+fun queryHasSelect(select: Select) = has("Select", { query: Query -> query.Select }, equalTo(select))

--- a/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbTableMapperTest.kt
+++ b/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbTableMapperTest.kt
@@ -166,7 +166,7 @@ class DynamoDbTableMapperTest {
     fun `custom query with DSL`() {
         val results = tableMapper.index(byOwner).query {
             keyCondition {
-                ownerIdAttr eq owner1
+                hashKey eq owner1
             }
             filterExpression {
                 val idExpr = idAttr eq kratos.id
@@ -183,7 +183,7 @@ class DynamoDbTableMapperTest {
     fun `custom query with filter functions in DSL`() {
         val results = tableMapper.index(byOwner).query {
             keyCondition {
-                ownerIdAttr eq owner1
+                hashKey eq owner1
             }
             filterExpression {
                 nameAttr contains "o"
@@ -274,7 +274,7 @@ class DynamoDbTableMapperTest {
         // page 1 of 2
         val page1 = tableMapper.index(byDob).queryPage(Limit = 1) {
             keyCondition {
-                bornAttr eq smokie.born
+                hashKey eq smokie.born
             }
         }
         assertThat(page1, equalTo(DynamoDbPage(
@@ -294,7 +294,7 @@ class DynamoDbTableMapperTest {
             )
         ) {
             keyCondition {
-                bornAttr eq smokie.born
+                hashKey eq smokie.born
             }
         }
         assertThat(
@@ -408,9 +408,9 @@ class DynamoDbTableMapperTest {
 
     @Test
     fun `count (via query)`() {
-        val totalCount = tableMapper.primaryIndex().count {
+        val totalCount = tableMapper.index(byOwner).count {
             keyCondition {
-                ownerIdAttr eq owner1
+                hashKey eq owner1
             }
         }
         assertThat(totalCount, equalTo(3))


### PR DESCRIPTION
In the `keyCondition` of a `query` the new values `hashKey` and `sortKey` should be used in place of actual attributes. This makes the DSL more typesafe (it prevents you from using the wrong attributes in the `keyCondition`) and it resolves the problem described in #380

Fixes https://github.com/http4k/http4k-connect/issues/380