### PR TITLE
Dynamodb index mapper custom projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This list is not intended to be all-encompassing - it will document major and breaking API 
 changes with their rationale when appropriate. Given version `A.B.C.D`, breaking changes are to be expected in version number increments where changes in the `A` or `B` sections:
 
+### v5.9.1.0 (uncut)
+- **http4k-connect-amazon-dynamodb** - [Breaking] `DynamoDbIndexMapper` now supports custom projections. Closes #391. H/T @oharaandrew314
+
 ### v5.9.0.0
 - **http4k-connect-amazon-dynamodb** - [Breaking] `keyCondition` in query DSL no longer accepts arbitrary attributes. Fixes #380. H/T @obecker
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This list is not intended to be all-encompassing - it will document major and breaking API 
 changes with their rationale when appropriate. Given version `A.B.C.D`, breaking changes are to be expected in version number increments where changes in the `A` or `B` sections:
 
-### v5.9.1.0 (uncut)
+### v5.10.0.0 (uncut)
 - **http4k-connect-amazon-dynamodb** - [Breaking] `DynamoDbIndexMapper` now supports custom projections. Closes #391. H/T @oharaandrew314
 
 ### v5.9.0.0

--- a/amazon/dynamodb/client/src/examples/kotlin/using_the_table_mapper.kt
+++ b/amazon/dynamodb/client/src/examples/kotlin/using_the_table_mapper.kt
@@ -26,10 +26,10 @@ private val ownerIdAttr = Attribute.uuid().required("ownerId")
 private val nameAttr = Attribute.string().required("name")
 
 // define the primary index
-private val primaryIndex = DynamoDbTableMapperSchema.Primary(idAttr)
+private val primaryIndex = DynamoDbTableMapperSchema.Primary<KittyCat, UUID>(idAttr)
 
 // define an optional secondary index
-private val ownerIndex = DynamoDbTableMapperSchema.GlobalSecondary(
+private val ownerIndex = DynamoDbTableMapperSchema.GlobalSecondary<KittyCat, UUID, UUID>(
     indexName = IndexName.of("owners"),
     hashKeyAttribute = ownerIdAttr,
     sortKeyAttribute = idAttr
@@ -41,7 +41,7 @@ fun main() {
     // define the table mapper and its primary index
     val table = dynamoDb.tableMapper<KittyCat, UUID, Unit>(
         tableName = TableName.of("cats"),
-        primarySchema = primaryIndex
+        primarySchema = primaryIndex,
     )
 
     // optionally, create the table and its secondary indexes

--- a/amazon/dynamodb/client/src/examples/kotlin/using_the_table_mapper.kt
+++ b/amazon/dynamodb/client/src/examples/kotlin/using_the_table_mapper.kt
@@ -41,7 +41,7 @@ fun main() {
     // define the table mapper and its primary index
     val table = dynamoDb.tableMapper<KittyCat, UUID, Unit>(
         tableName = TableName.of("cats"),
-        primarySchema = primaryIndex,
+        primarySchema = primaryIndex
     )
 
     // optionally, create the table and its secondary indexes

--- a/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryDsl.kt
+++ b/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryDsl.kt
@@ -20,7 +20,7 @@ interface PartitionKeyCondition<HashKey : Any, SortKey : Any> : CombinedKeyCondi
  * See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.KeyConditionExpressions.html
  */
 class KeyConditionBuilder<HashKey : Any, SortKey : Any> internal constructor(
-    schema: DynamoDbTableMapperSchema<HashKey, SortKey>
+    schema: DynamoDbTableMapperSchema<*, HashKey, SortKey>
 ) {
     inner class HashKeySubstitute(val attribute: Attribute<HashKey>) {
         val expressionAttributeName = "hk"
@@ -315,7 +315,7 @@ class DynamoDbScanBuilder {
     )
 }
 
-class DynamoDbQueryBuilder<HashKey : Any, SortKey : Any>(private val schema: DynamoDbTableMapperSchema<HashKey, SortKey>) {
+class DynamoDbQueryBuilder<HashKey : Any, SortKey : Any>(private val schema: DynamoDbTableMapperSchema<*, HashKey, SortKey>) {
 
     internal class DynamoDbQuery(
         val keyConditionExpression: String?,

--- a/amazon/dynamodb/client/src/test/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryDslTest.kt
+++ b/amazon/dynamodb/client/src/test/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbQueryDslTest.kt
@@ -52,7 +52,7 @@ class DynamoDbQueryDslTest {
     private val table =
         mockDynamoDb.tableMapper<MockDocument, UUID, String>(TableName.of("Table"), hashKeyAttr, sortKeyAttr)
     private val index = table.primaryIndex()
-    private val secondaryIndex = DynamoDbTableMapperSchema.GlobalSecondary<Int, Unit>(
+    private val secondaryIndex = DynamoDbTableMapperSchema.GlobalSecondary<MockDocument, Int, Unit>(
         indexName = IndexName.of("Secondary"),
         hashKeyAttribute = intAttr.asRequired(),
         sortKeyAttribute = null

--- a/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbTableMapperFixtures.kt
+++ b/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/mapper/DynamoDbTableMapperFixtures.kt
@@ -11,6 +11,14 @@ internal data class Cat(
     val born: LocalDate,
 )
 
+internal data class CatRef(
+    val ownerId: UUID,
+    val id: UUID,
+    val name: String
+)
+
+internal fun Cat.ref() = CatRef(ownerId, id, name)
+
 internal val owner1 = UUID.fromString("97f5acb1-7212-44f3-8ade-03cfa115c960")
 internal val owner2 = UUID.fromString("5100dd9e-b28f-4a3b-8641-ff9d39d9bb08")
 


### PR DESCRIPTION
This is a breaking change.  When defining indices, a type argument for the document is now required.

~~I seem to have a heisenbug where when I run all the local dynamo tests, one of them stalls.  But when I run that test class in isolation, it's fine.  I'm going to see if I can reproduce it in the build, or if it's just a local issue.~~  It's just my machine 🙃 

Closes #391 