### PR TITLE
Properly parse evidently project and features names from ARN

### DIFF
--- a/amazon/evidently/client/src/main/kotlin/org/http4k/connect/amazon/evidently/model/FeatureName.kt
+++ b/amazon/evidently/client/src/main/kotlin/org/http4k/connect/amazon/evidently/model/FeatureName.kt
@@ -1,12 +1,16 @@
 package org.http4k.connect.amazon.evidently.model
 
-import dev.forkhandles.values.StringValueFactory
+import dev.forkhandles.values.ValueFactory
 import dev.forkhandles.values.length
 import org.http4k.connect.amazon.core.model.ARN
 import org.http4k.connect.amazon.core.model.ResourceId
 
 class FeatureName private constructor(value: String) : ResourceId(value) {
-    companion object : StringValueFactory<FeatureName>(::FeatureName, (1..127).length) {
-        fun of(arn: ARN) = arn.resourceId(::FeatureName)
+    companion object : ValueFactory<FeatureName, String>(
+        coerceFn = ::FeatureName,
+        validation = (1..127).length,
+        parseFn = { it.split("/").last() }
+    ) {
+        fun of(arn: ARN) = arn.resourceId(FeatureName::parse)
     }
 }

--- a/amazon/evidently/client/src/main/kotlin/org/http4k/connect/amazon/evidently/model/ProjectName.kt
+++ b/amazon/evidently/client/src/main/kotlin/org/http4k/connect/amazon/evidently/model/ProjectName.kt
@@ -1,6 +1,6 @@
 package org.http4k.connect.amazon.evidently.model
 
-import dev.forkhandles.values.StringValueFactory
+import dev.forkhandles.values.ValueFactory
 import dev.forkhandles.values.and
 import dev.forkhandles.values.maxLength
 import dev.forkhandles.values.regex
@@ -8,7 +8,11 @@ import org.http4k.connect.amazon.core.model.ARN
 import org.http4k.connect.amazon.core.model.ResourceId
 
 class ProjectName private constructor(value: String) : ResourceId(value) {
-    companion object : StringValueFactory<ProjectName>(::ProjectName, 2048.maxLength.and("^[-a-zA-Z0-9._]*\$".regex)) {
-        fun of(arn: ARN) = arn.resourceId(::ProjectName)
+    companion object : ValueFactory<ProjectName, String>(
+        coerceFn = ::ProjectName,
+        validation = 2048.maxLength.and("^[-a-zA-Z0-9._]*\$".regex),
+        parseFn = { it.split("/").first() }
+    ) {
+        fun of(arn: ARN) = arn.resourceId(ProjectName::parse)
     }
 }

--- a/amazon/evidently/client/src/test/kotlin/org/http4k/connect/amazon/evidently/model/EvidentlyArnTest.kt
+++ b/amazon/evidently/client/src/test/kotlin/org/http4k/connect/amazon/evidently/model/EvidentlyArnTest.kt
@@ -1,17 +1,29 @@
 package org.http4k.connect.amazon.evidently.model
 
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
 import org.http4k.connect.amazon.core.model.ARN
 import org.http4k.connect.amazon.core.model.AwsAccount
-import org.http4k.connect.amazon.core.model.AwsService
 import org.http4k.connect.amazon.core.model.Region
 import org.http4k.connect.amazon.evidently.Evidently
+import org.junit.jupiter.api.Test
 
-class ProjectNameTest {
+class EvidentlyArnTest {
 
     private val arn = ARN.of(
         awsService = Evidently.awsService,
         region = Region.CA_CENTRAL_1,
         account = AwsAccount.of("1234567890"),
-        resourcePath = "projects/my_project/feature/my_feature"
+        resourcePath = "project/my_project/feature/my_feature"
     )
+
+    @Test
+    fun `get project name`() {
+        assertThat(ProjectName.of(arn), equalTo(ProjectName.of("my_project")))
+    }
+
+    @Test
+    fun `get feature name`() {
+        assertThat(FeatureName.of(arn), equalTo(FeatureName.of("my_feature")))
+    }
 }

--- a/amazon/evidently/client/src/test/kotlin/org/http4k/connect/amazon/evidently/model/EvidentlyArnTest.kt
+++ b/amazon/evidently/client/src/test/kotlin/org/http4k/connect/amazon/evidently/model/EvidentlyArnTest.kt
@@ -1,0 +1,17 @@
+package org.http4k.connect.amazon.evidently.model
+
+import org.http4k.connect.amazon.core.model.ARN
+import org.http4k.connect.amazon.core.model.AwsAccount
+import org.http4k.connect.amazon.core.model.AwsService
+import org.http4k.connect.amazon.core.model.Region
+import org.http4k.connect.amazon.evidently.Evidently
+
+class ProjectNameTest {
+
+    private val arn = ARN.of(
+        awsService = Evidently.awsService,
+        region = Region.CA_CENTRAL_1,
+        account = AwsAccount.of("1234567890"),
+        resourcePath = "projects/my_project/feature/my_feature"
+    )
+}


### PR DESCRIPTION
Closes #405 

This isn't perfect, because someone can still do `arn.resourceId(::ProjectName)`.  They have to do `arn.resourceId(ProjectName::parse)` or `ProjectName.of(arn)` due to how the `ARN.resourceId` function works.
