### PR TITLE
Fix s3:createBucket request body for default (us-east-1) region

### DIFF
--- a/amazon/s3/client/src/main/kotlin/org/http4k/connect/amazon/s3/action/CreateBucket.kt
+++ b/amazon/s3/client/src/main/kotlin/org/http4k/connect/amazon/s3/action/CreateBucket.kt
@@ -12,16 +12,20 @@ import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Uri
 
+private val defaultBucketRegion = Region.US_EAST_1
+
 @Http4kConnectAction
 data class CreateBucket(val bucketName: BucketName, val region: Region) : S3Action<Unit> {
     private fun uri() = Uri.of("/${bucketName}")
 
-    override fun toRequest() = Request(PUT, uri()).body(
-        """<?xml version="1.0" encoding="UTF-8"?>
+    override fun toRequest() = Request(PUT, uri()).let {
+        if (region == defaultBucketRegion) it else it.body(
+"""<?xml version="1.0" encoding="UTF-8"?>
 <CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
     <LocationConstraint>${region}</LocationConstraint>
 </CreateBucketConfiguration>"""
-    )
+)
+    }
 
     override fun toResult(response: Response) = with(response) {
         when {

--- a/amazon/s3/client/src/test/kotlin/org/http4k/connect/amazon/s3/S3GlobalContract.kt
+++ b/amazon/s3/client/src/test/kotlin/org/http4k/connect/amazon/s3/S3GlobalContract.kt
@@ -4,6 +4,7 @@ import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import dev.forkhandles.result4k.Success
 import org.http4k.connect.amazon.AwsContract
+import org.http4k.connect.amazon.core.model.Region
 import org.http4k.connect.amazon.s3.model.BucketName
 import org.http4k.connect.successValue
 import org.http4k.core.HttpHandler
@@ -11,7 +12,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
-abstract class S3GlobalContract(http: HttpHandler) : AwsContract() {
+abstract class S3GlobalContract(private val http: HttpHandler) : AwsContract() {
     private val s3 by lazy {
         S3.Http({ aws.credentials }, http)
     }
@@ -38,6 +39,14 @@ abstract class S3GlobalContract(http: HttpHandler) : AwsContract() {
         } finally {
             s3Bucket.deleteBucket().successValue()
         }
+    }
+
+    @Test
+    fun `create bucket in default (us-east-1) region`() {
+        assertThat(s3.createBucket(bucket, Region.US_EAST_1), equalTo(Success(Unit)))
+
+        val s3Bucket = S3Bucket.Http(bucket, Region.US_EAST_1, { aws.credentials }, http)
+        s3Bucket.deleteBucket().successValue()
     }
 }
 


### PR DESCRIPTION
This is really dumb, but if you give a location constraint for the default (us-east-1) S3 region, the request fails.  And if you put an empty `CreateBucketConfiguration` element, the request fails.  So an XML body is only added if the region is non-default.