### PR TITLE
Fix type of SQS ReceiveMessage waitTimeSeconds parameter

### DIFF
--- a/amazon/sqs/client/src/main/kotlin/org/http4k/connect/amazon/sqs/action/ReceiveMessage.kt
+++ b/amazon/sqs/client/src/main/kotlin/org/http4k/connect/amazon/sqs/action/ReceiveMessage.kt
@@ -15,7 +15,7 @@ data class ReceiveMessage(
     @Json(name = "MaxNumberOfMessages") val maxNumberOfMessages: Int? = null,
     @Json(name = "VisibilityTimeout") val visibilityTimeout: Int? = null,
     val expires: ZonedDateTime? = null,
-    @Json(name = "WaitTimeSeconds") val longPollTime: Duration? = null,
+    @Json(name = "WaitTimeSeconds") val waitTimeSeconds: Int? = null,
     @Json(name = "MessageAttributeNames") val messageAttributes: List<String>? = null,
     @Json(name = "EeceiveRequestAttemptId") val receiveRequestAttemptId: String? = null,
     @Json(name = "AttributeNames") val attributeNames: List<String>? = null,

--- a/amazon/sqs/client/src/test/kotlin/org/http4k/connect/amazon/sqs/SQSContract.kt
+++ b/amazon/sqs/client/src/test/kotlin/org/http4k/connect/amazon/sqs/SQSContract.kt
@@ -80,7 +80,8 @@ abstract class SQSContract(http: HttpHandler) : AwsContract() {
 
                 val received = receiveMessage(
                     queueUrl,
-                    messageAttributes = listOf("foo", "bar", "binaryfoo")
+                    messageAttributes = listOf("foo", "bar", "binaryfoo"),
+                    waitTimeSeconds = 2
                 ).successValue().first()
 
                 assertThat(received.messageId, equalTo(id))

--- a/amazon/sqs/fake/src/test/kotlin/org/http4k/connect/amazon/sqs/FakeSQSTest.kt
+++ b/amazon/sqs/fake/src/test/kotlin/org/http4k/connect/amazon/sqs/FakeSQSTest.kt
@@ -6,7 +6,6 @@ import org.http4k.connect.amazon.core.model.Tag
 import org.http4k.connect.amazon.fakeAwsEnvironment
 import org.http4k.connect.successValue
 import org.junit.jupiter.api.Test
-import java.time.Duration
 
 class FakeSQSTest : SQSContract(FakeSQS()) {
     override val aws = fakeAwsEnvironment
@@ -29,7 +28,7 @@ class FakeSQSTest : SQSContract(FakeSQS()) {
                 val messages = receiveMessage(
                     created.QueueUrl,
                     maxNumberOfMessages = 2,
-                    longPollTime = Duration.ofSeconds(10)
+                    waitTimeSeconds = 10
                 ).successValue()
                 assertThat(messages.size, equalTo(2))
                 assertThat(messages[0].messageId, equalTo(id))


### PR DESCRIPTION
This is a breaking change.  If we wish for it to not be breaking, there are overrides I can perform to make it so.