### PR TITLE
AWS Cognito: Add support for server side authentication (AdminInitiateAuth and AdminRespondToAuthChallenge)

### DIFF
--- a/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/CognitoMoshi.kt
+++ b/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/CognitoMoshi.kt
@@ -10,11 +10,16 @@ import org.http4k.connect.amazon.cognito.model.ClientSecret
 import org.http4k.connect.amazon.cognito.model.CloudFrontDomain
 import org.http4k.connect.amazon.cognito.model.ConfirmationCode
 import org.http4k.connect.amazon.cognito.model.Destination
+import org.http4k.connect.amazon.cognito.model.HeaderName
+import org.http4k.connect.amazon.cognito.model.HeaderValue
 import org.http4k.connect.amazon.cognito.model.IdToken
+import org.http4k.connect.amazon.cognito.model.IpAddress
 import org.http4k.connect.amazon.cognito.model.PoolName
 import org.http4k.connect.amazon.cognito.model.RefreshToken
 import org.http4k.connect.amazon.cognito.model.SecretCode
 import org.http4k.connect.amazon.cognito.model.SecretHash
+import org.http4k.connect.amazon.cognito.model.ServerName
+import org.http4k.connect.amazon.cognito.model.ServerPath
 import org.http4k.connect.amazon.cognito.model.Session
 import org.http4k.connect.amazon.cognito.model.UserCode
 import org.http4k.connect.amazon.cognito.model.UserPoolId
@@ -46,12 +51,17 @@ object CognitoMoshi : ConfigurableMoshi(
         .value(ClientSecret)
         .value(ConfirmationCode)
         .value(Destination)
+        .value(HeaderName)
+        .value(HeaderValue)
         .value(IdToken)
+        .value(IpAddress)
         .value(RefreshToken)
         .value(Password)
         .value(PoolName)
         .value(SecretCode)
         .value(SecretHash)
+        .value(ServerName)
+        .value(ServerPath)
         .value(Session)
         .value(UserCode)
         .value(Username)

--- a/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/AdminInitiateAuth.kt
+++ b/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/AdminInitiateAuth.kt
@@ -1,0 +1,22 @@
+package org.http4k.connect.amazon.cognito.action
+
+import org.http4k.connect.Http4kConnectAction
+import org.http4k.connect.amazon.cognito.CognitoAction
+import org.http4k.connect.amazon.cognito.model.AnalyticsMetadata
+import org.http4k.connect.amazon.cognito.model.AuthFlow
+import org.http4k.connect.amazon.cognito.model.ClientId
+import org.http4k.connect.amazon.cognito.model.ContextData
+import org.http4k.connect.amazon.cognito.model.UserPoolId
+import se.ansman.kotshi.JsonSerializable
+
+@Http4kConnectAction
+@JsonSerializable
+data class AdminInitiateAuth(
+    val ClientId: ClientId,
+    val AuthFlow: AuthFlow,
+    val UserPoolId: UserPoolId,
+    val AuthParameters: Map<String, String>? = null,
+    val ClientMetadata: Map<String, String>? = null,
+    val ContextData: ContextData? = null,
+    val AnalyticsMetadata: AnalyticsMetadata? = null
+) : CognitoAction<AuthInitiated>(AuthInitiated::class)

--- a/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/AdminRespondToAuthChallenge.kt
+++ b/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/AdminRespondToAuthChallenge.kt
@@ -1,0 +1,24 @@
+package org.http4k.connect.amazon.cognito.action
+
+import org.http4k.connect.Http4kConnectAction
+import org.http4k.connect.amazon.cognito.CognitoAction
+import org.http4k.connect.amazon.cognito.model.AnalyticsMetadata
+import org.http4k.connect.amazon.cognito.model.ChallengeName
+import org.http4k.connect.amazon.cognito.model.ClientId
+import org.http4k.connect.amazon.cognito.model.ContextData
+import org.http4k.connect.amazon.cognito.model.Session
+import org.http4k.connect.amazon.cognito.model.UserPoolId
+import se.ansman.kotshi.JsonSerializable
+
+@Http4kConnectAction
+@JsonSerializable
+data class AdminRespondToAuthChallenge(
+    val ChallengeName: ChallengeName,
+    val ClientId: ClientId,
+    val UserPoolId: UserPoolId,
+    val Session: Session? = null,
+    val ClientMetadata: Map<String, String>? = null,
+    val ContextData: ContextData? = null,
+    val ChallengeResponses: Map<String, String>? = null,
+    val AnalyticsMetadata: AnalyticsMetadata? = null
+) : CognitoAction<AuthInitiated>(AuthInitiated::class)

--- a/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/InitiateAuth.kt
+++ b/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/InitiateAuth.kt
@@ -24,8 +24,8 @@ data class InitiateAuth(
 
 @JsonSerializable
 data class AuthInitiated(
-    val AuthenticationResult: AuthenticationResult,
+    val AuthenticationResult: AuthenticationResult?,
     val ChallengeName: ChallengeName?,
-    val ChallengeParameters: Map<String, String>,
+    val ChallengeParameters: Map<String, String>?,
     val Session: Session?
 )

--- a/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/model/cognito.kt
+++ b/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/model/cognito.kt
@@ -70,11 +70,13 @@ class SecretHash private constructor(value: String) : StringValue(value) {
     companion object : NonBlankStringValueFactory<SecretHash>(::SecretHash)
 }
 
+@JsonSerializable
 data class NewDeviceMetadata(
     val DeviceGroupKey: String? = null,
     val DeviceKey: String? = null
 )
 
+@JsonSerializable
 data class AuthenticationResult(
     val AccessToken: AccessToken? = null,
     val ExpiresIn: Int? = null,

--- a/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/model/cognito.kt
+++ b/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/model/cognito.kt
@@ -414,9 +414,44 @@ class AttributeName private constructor(value: String) : StringValue(value) {
     companion object : NonBlankStringValueFactory<AttributeName>(::AttributeName)
 }
 
+class HeaderName private constructor(value: String) : StringValue(value) {
+    companion object : NonBlankStringValueFactory<HeaderName>(::HeaderName)
+}
+
+class HeaderValue private constructor(value: String) : StringValue(value) {
+    companion object : NonBlankStringValueFactory<HeaderValue>(::HeaderValue)
+}
+
+class IpAddress private constructor(value: String) : StringValue(value) {
+    companion object : NonBlankStringValueFactory<IpAddress>(::IpAddress)
+}
+
+class ServerName private constructor(value: String) : StringValue(value) {
+    companion object : NonBlankStringValueFactory<ServerName>(::ServerName)
+}
+
+class ServerPath private constructor(value: String) : StringValue(value) {
+    companion object : NonBlankStringValueFactory<ServerPath>(::ServerPath)
+}
+
 @JsonSerializable
 data class CodeDeliveryDetails(
     val AttributeName: AttributeName?,
     val DeliveryMedium: DeliveryMedium?,
     val Destination: Destination?
+)
+
+@JsonSerializable
+data class ContextData(
+    val HttpHeaders: List<HttpHeader>,
+    val IpAddress: IpAddress,
+    val ServerName: ServerName,
+    val ServerPath: ServerPath,
+    val EncodedData: String? = null
+)
+
+@JsonSerializable
+data class HttpHeader(
+    val headerName: HeaderName? = null,
+    val headerValue: HeaderValue? = null
 )

--- a/amazon/cognito/client/src/test/kotlin/org/http4k/connect/amazon/cognito/ActualCognitoResponsesTest.kt
+++ b/amazon/cognito/client/src/test/kotlin/org/http4k/connect/amazon/cognito/ActualCognitoResponsesTest.kt
@@ -4,8 +4,10 @@ import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import org.http4k.connect.amazon.cognito.action.AuthInitiated
 import org.http4k.connect.amazon.cognito.model.AccessToken
+import org.http4k.connect.amazon.cognito.model.ChallengeName
 import org.http4k.connect.amazon.cognito.model.IdToken
 import org.http4k.connect.amazon.cognito.model.RefreshToken
+import org.http4k.connect.amazon.cognito.model.Session
 import org.junit.jupiter.api.Test
 
 class ActualCognitoResponsesTest {
@@ -24,11 +26,34 @@ class ActualCognitoResponsesTest {
             "ChallengeParameters":{}}
         """.trimIndent()
         )
-        assertThat(response.AuthenticationResult.AccessToken, equalTo(AccessToken.of("access-token")))
-        assertThat(response.AuthenticationResult.ExpiresIn, equalTo(3600))
-        assertThat(response.AuthenticationResult.IdToken, equalTo(IdToken.of("id-token")))
-        assertThat(response.AuthenticationResult.RefreshToken, equalTo(RefreshToken.of("refresh-token")))
-        assertThat(response.AuthenticationResult.TokenType, equalTo("Bearer"))
+        assertThat(response.AuthenticationResult?.AccessToken, equalTo(AccessToken.of("access-token")))
+        assertThat(response.AuthenticationResult?.ExpiresIn, equalTo(3600))
+        assertThat(response.AuthenticationResult?.IdToken, equalTo(IdToken.of("id-token")))
+        assertThat(response.AuthenticationResult?.RefreshToken, equalTo(RefreshToken.of("refresh-token")))
+        assertThat(response.AuthenticationResult?.TokenType, equalTo("Bearer"))
         assertThat(response.ChallengeParameters, equalTo(mapOf()))
+    }
+
+    @Test
+    fun `deserializing a user password response with a challenge`() {
+        val response = factory.asA<AuthInitiated>(
+            """
+                {
+                  "ChallengeName": "NEW_PASSWORD_REQUIRED",
+                  "ChallengeParameters": {
+                    "USER_ID_FOR_SRP": "user",
+                    "requiredAttributes": "[]"
+                  },
+                  "Session": "session.id"
+                }
+            """.trimIndent()
+        )
+
+        assertThat(response.ChallengeName, equalTo(ChallengeName.NEW_PASSWORD_REQUIRED))
+        assertThat(
+            response.ChallengeParameters,
+            equalTo(mapOf("USER_ID_FOR_SRP" to "user", "requiredAttributes" to "[]"))
+        )
+        assertThat(response.Session, equalTo(Session.of("session.id")))
     }
 }


### PR DESCRIPTION
Support the server-side authentication flow with AdminInitiateAuth and AdminRespondToAuthChallenge.